### PR TITLE
Optional click action for the rows in password list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@
 * You can now access the [app](http://localhost/index.php/apps/passwords)
 
 #### Sample Data
-A [file with sample data](https://git.mdns.eu/nextcloud/passwords/wikis/Developers/_files/Sample%20Passwords.json) is available in the wiki and can be imported on the [backups page](http://localhost/index.php/apps/passwords#/backup).
+A [file with sample data](https://git.mdns.eu/nextcloud/passwords/wikis/Developers/_files/SamplePasswords.json) is available in the wiki and can be imported on the [backups page](http://localhost/index.php/apps/passwords#/backup).
 
 #### Helpful commands
 * `npm run start` - Start the docker server

--- a/src/js/Manager/SettingsManager.js
+++ b/src/js/Manager/SettingsManager.js
@@ -12,6 +12,7 @@ class SettingsManager {
             'local.ui.sort.field'             : 'label',
             'client.ui.section.default'       : 'all',
             'client.ui.password.field.title'  : 'label',
+            'client.ui.password.click.action' : 'copyPassword',
             'client.ui.password.field.sorting': 'byTitle',
             'client.ui.password.menu.copy'    : false,
             'client.ui.list.tags.show'        : false

--- a/src/vue/Line/Password.vue
+++ b/src/vue/Line/Password.vue
@@ -119,7 +119,6 @@
         methods: {
             rowClickAction($event) {
               const action = SettingsManager.get('client.ui.password.click.action');
-              console.log("Action is", action);
               if (action === 'copyPassword') return this.copyPasswordAction($event);
               if (action === 'showDetails')  return this.detailsAction($event);
               if (action === 'copyWebsite')  return this.copyUrlAction();

--- a/src/vue/Line/Password.vue
+++ b/src/vue/Line/Password.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="row password"
-         @click="copyPasswordAction($event)"
+         @click="rowClickAction($event)"
          @dblclick="copyUsernameAction($event)"
          @dragstart="dragStartAction($event)"
          :data-password-id="password.id"
@@ -117,6 +117,13 @@
         },
 
         methods: {
+            rowClickAction($event) {
+              const action = SettingsManager.get('client.ui.password.click.action');
+              console.log("Action is", action);
+              if (action === 'copyPassword') return this.copyPasswordAction($event);
+              if (action === 'showDetails')  return this.detailsAction($event);
+              if (action === 'copyWebsite')  return this.copyUrlAction();
+            },
             copyPasswordAction($event) {
                 if($event && ($event.detail !== 1 || $($event.target).closest('.more').length !== 0)) return;
                 Utility.copyToClipboard(this.password.password);

--- a/src/vue/Section/Settings.vue
+++ b/src/vue/Section/Settings.vue
@@ -37,7 +37,6 @@
                 </select>
                 <settings-help text="The initial section to be shown when the app is opened"/>
 
-                <translate tag="h3" say="Passwords List View"/>
                 <translate tag="label" for="setting-password-title" say="Set title from"/>
                 <select id="setting-password-title" v-model="settings['client.ui.password.field.title']">
                     <translate tag="option" value="label" say="Name"/>
@@ -45,6 +44,15 @@
                     <translate tag="option" value="user" say="Username"/>
                 </select>
                 <settings-help text="Show the selected property as title in the list view"/>
+
+                <translate tag="h3" say="Passwords List Click Action"/>
+                <translate tag="label" for="setting-password-click" say="On password row click"/>
+                <select id="setting-password-click" v-model="settings['client.ui.password.click.action']">
+                    <translate tag="option" value="showDetails" say="Show details"/>
+                    <translate tag="option" value="copyPassword" say="Copy password"/>
+                    <translate tag="option" value="copyWebsite" say="Copy website URL"/>
+                </select>
+                <settings-help text="Perform the selected action when clicking on an item in the list view"/>
 
                 <translate tag="label" for="setting-password-sorting" say="Sort by"/>
                 <select id="setting-password-sorting" v-model="settings['client.ui.password.field.sorting']">


### PR DESCRIPTION
Personally I found it a bit counter-intuitive that the copy action is more "handy" than opening the details pane - so I made a quick edit to make the behaviour configurable.