### PR TITLE
Fix incorrect 'Every week' value interval

### DIFF
--- a/src/lib/Settings/AdminSettings.php
+++ b/src/lib/Settings/AdminSettings.php
@@ -302,7 +302,7 @@ class AdminSettings implements ISettings {
                 21600   => 'Every six hours',
                 86400   => 'Every day',
                 172800  => 'Every two days',
-                43200   => 'Every week',
+                604800  => 'Every week',
                 1209600 => 'Every two weeks'
             ]
         ];


### PR DESCRIPTION
I suppose this is an unfortunate value typo. I was looking through the changes and noticed this and judging by the rest of those values the "weekly" one should be in seconds as well.