### PR TITLE
Add new api setting domain mappings

### DIFF
--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -59,6 +59,13 @@ class PasswordsAdminSettings {
             () => { PasswordsAdminSettings._updateApiField('preview'); }
         );
 
+        var mapping = document.getElementById('domain-mapping-custom').childNodes[0]
+        mapping = JSON.parse(mapping.data);
+        mapping.data.forEach(element => {
+            this._addLineToTable(element.join(' '));
+        });
+        this._addLineToTable();
+
         PasswordsAdminSettings._updateApiField('favicon');
         PasswordsAdminSettings._updateApiField('preview');
     }
@@ -133,6 +140,74 @@ class PasswordsAdminSettings {
             $apiInput.attr('data-setting', data.key);
             $apiInput.val(data.value);
         }
+    }
+
+    /**
+     * Save domain mapping settings back to settings
+     *
+     * @private
+     */
+    _onChangeCustomDomainMapping() {
+        var result = [];
+        for (var i = 0; i < $('.domain-mapping-custom').length; i++) { 
+           var element = $('.domain-mapping-custom').eq(i);
+
+           if(element.val() === "") {
+               element.remove();
+           } else {
+               var mapping = element.val().split(' ').filter(function (el) {
+                    return el != null && el !== "";
+                });
+                result.push(mapping);
+           }
+        }
+        this._addLineToTable();
+        this.api.set('domain.mapping.custom', JSON.stringify({data: result}))
+            .then((d) => {
+                this._showMessage('saved', `[id="domain-mapping-table"]`);
+            })
+            .catch((d) => {
+                this._showMessage('error', `[id="domain-mapping-table"]`);
+                if(d.message) OC.Notification.show(PasswordsAdminSettings._translate(d.message));
+            });
+    }
+
+    /**
+     * Add a new line to the custom domain mapping table
+     *
+     * @param value
+     * @private
+     */
+    _addLineToTable(value = "") {
+        var table = document.getElementById('domain-mapping-table');
+        
+        var input = document.createElement("input");
+        input.type = "text";
+        input.className = "domain-mapping-custom";
+        input.value = value;
+        this._addDomainMappingEventListener(input);
+
+        var td = document.createElement("td");
+        td.appendChild(input);
+
+        var tr = document.createElement("tr");
+        tr.appendChild(td);
+
+        table.appendChild(tr);
+    }
+
+    /**
+     * Add event to custom domain mapping input fields
+     *
+     * @param value
+     * @private
+     */
+    _addDomainMappingEventListener(element) {
+      //  $('.domain-mapping-custom').off('change');
+        $(element).on(
+            'change',
+            () => { this._onChangeCustomDomainMapping(); }
+        );
     }
 }
 

--- a/src/l10n/de.json
+++ b/src/l10n/de.json
@@ -180,7 +180,11 @@
         "A new client or app was connected to your account"                                         : "Eine neue App wurde mit deinem Konto verknüpft",
         "\"%s\" was granted access to your %s Passwords account via PassLink."                      : "\"%s\" wurde Zugriff auf dein %s Passwörter Konto mittels PassLink gewährt.",
         "You can manage all connected devices and apps in your %s settings in the security section.": "Du kannst alle verknüpften Geräte und Apps in den %s Einstellungen im Bereich \"Sicherheit\" verwalten.",
-        "Background jobs are run with PHP %1$s, the webserver uses PHP %2$s. This may cause issues.": "Hintergrundaufgaben werden mit PHP %1$s ausgeführt, der Webserver verwendet aber %2$s. Dies kann Probleme verursachen."
+        "Background jobs are run with PHP %1$s, the webserver uses PHP %2$s. This may cause issues.": "Hintergrundaufgaben werden mit PHP %1$s ausgeführt, der Webserver verwendet aber %2$s. Dies kann Probleme verursachen.",
+        "Domain mappings"                                                                           : "Domain Zuordnungen",
+        "Include default domain list in search"                                                     : "Standard Domainliste in die Suche einbeziehen.",
+        "Default domain mapping list"                                                               : "Standard Domain Zuordnungsliste",
+        "Custom domain mapping list"                                                                : "Benutzerdefinierte Domain Zuordnungsliste"
     },
     "pluralForm"  : "nplurals=2; plural=(n != 1);"
 }

--- a/src/l10n/de_DE.json
+++ b/src/l10n/de_DE.json
@@ -180,7 +180,11 @@
         "A new client or app was connected to your account"                                         : "Eine neue App wurde mit Ihrem Konto verknüpft",
         "\"%s\" was granted access to your %s Passwords account via PassLink."                      : "\"%s\" wurde mittels PassLink Zugriff auf Ihr %s Konto gewährt.",
         "You can manage all connected devices and apps in your %s settings in the security section.": "Sie können alle verknüpften Geräte und Apps in den %s Einstellungen im Bereich \"Sicherheit\" verwalten.",
-        "Background jobs are run with PHP %1$s, the webserver uses PHP %2$s. This may cause issues.": "Hintergrundaufgaben werden mit PHP %1$s ausgeführt, der Webserver verwendet aber %2$s. Dies kann Probleme verursachen."
+        "Background jobs are run with PHP %1$s, the webserver uses PHP %2$s. This may cause issues.": "Hintergrundaufgaben werden mit PHP %1$s ausgeführt, der Webserver verwendet aber %2$s. Dies kann Probleme verursachen.",
+        "Domain mappings"                                                                           : "Domain Zuordnungen",
+        "Include default domain list in search"                                                     : "Standard Domainliste in die Suche einbeziehen.",
+        "Default domain mapping list"                                                               : "Standard Domain Zuordnungsliste",
+        "Custom domain mapping list"                                                                : "Benutzerdefinierte Domain Zuordnungsliste"
     },
     "pluralForm"  : "nplurals=2; plural=(n != 1);"
 }

--- a/src/lib/Helper/AppSettings/DomainSettingsHelper.php
+++ b/src/lib/Helper/AppSettings/DomainSettingsHelper.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of the Passwords App
+ * created by Marius David Wieschollek
+ * and licensed under the AGPL.
+ */
+
+namespace OCA\Passwords\Helper\AppSettings;
+
+use OCA\Passwords\Services\ConfigurationService;
+use OCP\IL10N;
+
+/**
+ * Class DomainSettingsHelper
+ *
+ * @package OCA\Passwords\Helper\AppSettings
+ */
+class DomainSettingsHelper extends AbstractSettingsHelper {
+
+        /**
+     * @var IL10N
+     */
+    protected IL10N $localisation;
+
+    /**
+     * @var string
+     */
+    protected string $scope = 'domain';
+
+    /**
+     * @var array
+     */
+    protected array $keys
+        = [
+            'mapping.default.enabled' => 'domain/mapping/default/enabled',
+            'mapping.custom'          => 'domain/mapping/custom'
+        ];
+
+    /**
+     * @var array
+     */
+    protected array $types
+        = [
+            'mapping.default.enabled' => 'boolean',
+            'mapping.custom'          => 'string'
+        ];
+
+    /**
+     * @var array
+     */
+    protected array $defaults
+        = [
+            'mapping.default.enabled' => false,
+            'mapping.custom'          => "{\"data\":[]}"
+        ];
+
+}

--- a/src/lib/Helper/Settings/DomainSettingsHelper.php
+++ b/src/lib/Helper/Settings/DomainSettingsHelper.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * This file is part of the Passwords App
+ * created by Marius David Wieschollek
+ * and licensed under the AGPL.
+ */
+
+namespace OCA\Passwords\Helper\Settings;
+
+use OCA\Passwords\Services\ConfigurationService;
+
+/**
+ * Class DomainSettingsHelper
+ *
+ * @package OCA\Passwords\Helper\Settings
+ */
+class DomainSettingsHelper {
+
+    /**
+     * @var null|string
+     */
+    protected ?string $userId;
+
+    /**
+     * @var ConfigurationService
+     */
+    protected ConfigurationService $config;
+
+    /**
+     * DomainSettingsHelper constructor.
+     *
+     * @param null|string          $userId
+     * @param ConfigurationService $config
+     */
+    public function __construct(?string $userId, ConfigurationService $config) {
+        $this->config       = $config;
+        $this->userId       = $userId;
+    }
+
+    /**
+     * @param $key
+     *
+     * @return mixed
+     */
+    public function get($key) {
+        switch($key) {
+            case 'mapping':
+                return $this->getCurrentMapping();
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array
+     */
+    public function list(): array {
+        return [
+            'server.domain.mapping'         => $this->get('mapping')
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getCurrentMapping(): array {
+        $useDefault = $this->config->getAppValue('domain/mapping/default/enabled', true);
+        $customSettings = $this->config->getAppValue('domain/mapping/custom', "{\"data\":[]}");
+        $customSettings = json_decode(stripslashes($customSettings));
+        if ($useDefault) {
+            return array_merge($customSettings->data, $this->getDefaultMappings());
+        }
+        return $customSettings->data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDefaultMappings(): array {
+        $array = array(
+            array("apple.com", "icloud.com"),
+            array("bing.com hotmail.com", "live.com", "microsoft.com", "msn.com", "windows.com", "windowsazure.com", "office.com", "skype.com", "azure.com"),
+            array("youtube.com", "google.com", "gmail.com"),
+            array("amazon.com", "aws.com", "amazon.co.uk", "amazon.ca", "amazon.de", "amazon.fr", "amazon.es", "amazon.it", "amazon.com.au"),
+            array("gotomeeting.com", "citrixonline.com", "logmein.com"),
+            array("mysql.com", "oracle.com"),
+            array("alibaba.com", "aliexpress.com"),
+            array("t-online.de", "telekom.de", "telekom.com"),
+            array("autodesk.com", "tinkercad.com"),
+            array("firefox.com", "mozilla.org"),
+            array("facebook.com", "messenger.com"),
+            array("mymerrill.com", "ml.com", "merrilledge.com"),
+            array("ea.com", "origin.com"),
+            array("steampowered.com", "steamcommunity.com"),
+            array("go.com", "disney.com", "disney.de", "disneyplus.com", "d23.com", "shopdisney.com"),
+            array("ebay.com", "ebay.at", "ebay.be", "ebay.co.uk", "ebay.de", "ebay.es", "ebay.fr", "ebay.it", "ebay.nl", "ebay.pl"),
+            array("yahoo.com", "flickr.com"),
+            array("askubuntu.com", "mathoverflow.net", "serverfault.com", "stackapps.com", "stackexchange.com", "stackoverflow.com", "superuser.com")
+        );
+        return $array;
+    }
+}

--- a/src/lib/Helper/Settings/ServerSettingsHelper.php
+++ b/src/lib/Helper/Settings/ServerSettingsHelper.php
@@ -41,23 +41,31 @@ class ServerSettingsHelper {
     protected ThemeSettingsHelper $themeSettings;
 
     /**
+     * @var DomainSettingsHelper
+     */
+    protected DomainSettingsHelper $domainSettings;
+
+    /**
      * ServerSettingsHelper constructor.
      *
      * @param IURLGenerator        $urlGenerator
      * @param ConfigurationService $config
      * @param ShareSettingsHelper  $shareSettings
      * @param ThemeSettingsHelper  $themeSettings
+     * @param DomainSettingsHelper $domainSettings
      */
     public function __construct(
         IURLGenerator $urlGenerator,
         ConfigurationService $config,
         ShareSettingsHelper $shareSettings,
-        ThemeSettingsHelper $themeSettings
+        ThemeSettingsHelper $themeSettings,
+        DomainSettingsHelper $domainSettings
     ) {
         $this->urlGenerator  = $urlGenerator;
         $this->shareSettings = $shareSettings;
         $this->themeSettings = $themeSettings;
         $this->config        = $config;
+        $this->domainSettings = $domainSettings;
     }
 
     /**
@@ -90,6 +98,8 @@ class ServerSettingsHelper {
                 return $this->themeSettings->get($subKey);
             case 'sharing':
                 return $this->shareSettings->get($subKey);
+            case 'domain':
+                return $this->domainSettings->get($subKey);
             case 'handbook':
                 if($subKey !== 'url') return null;
                 $handbookUrl = $this->config->getAppValue('handbook/url', self::SERVER_MANUAL_URL);
@@ -114,7 +124,8 @@ class ServerSettingsHelper {
                 'server.performance'    => $this->get('performance')
             ],
             $this->themeSettings->list(),
-            $this->shareSettings->list()
+            $this->shareSettings->list(),
+            $this->domainSettings->list()
         );
     }
 

--- a/src/lib/Services/AppSettingsService.php
+++ b/src/lib/Services/AppSettingsService.php
@@ -15,6 +15,7 @@ use OCA\Passwords\Helper\AppSettings\LegacyApiSettingsHelper;
 use OCA\Passwords\Helper\AppSettings\NightlySettingsHelper;
 use OCA\Passwords\Helper\AppSettings\ServiceSettingsHelper;
 use OCA\Passwords\Helper\AppSettings\SurveySettingsHelper;
+use OCA\Passwords\Helper\AppSettings\DomainSettingsHelper;
 
 /**
  * Class AppSettingsService
@@ -59,6 +60,11 @@ class AppSettingsService {
     protected LegacyApiSettingsHelper $legacyApiSettings;
 
     /**
+     * @var DomainSettingsHelper
+     */
+    protected DomainSettingsHelper $domainSettings;
+
+    /**
      * AppSettingsService constructor.
      *
      * @param EntitySettingsHelper    $entitySettingsHelper
@@ -68,6 +74,7 @@ class AppSettingsService {
      * @param NightlySettingsHelper   $nightlySettingsHelper
      * @param DefaultSettingsHelper   $defaultSettingsHelper
      * @param LegacyApiSettingsHelper $legacyApiSettingsHelper
+     * @param DomainSettingsHelper    $domainSettingsHelper
      */
     public function __construct(
         EntitySettingsHelper $entitySettingsHelper,
@@ -76,7 +83,8 @@ class AppSettingsService {
         ServiceSettingsHelper $serviceSettingsHelper,
         NightlySettingsHelper $nightlySettingsHelper,
         DefaultSettingsHelper $defaultSettingsHelper,
-        LegacyApiSettingsHelper $legacyApiSettingsHelper
+        LegacyApiSettingsHelper $legacyApiSettingsHelper,
+        DomainSettingsHelper $domainSettingsHelper
     ) {
         $this->entitySettings    = $entitySettingsHelper;
         $this->backupSettings    = $backupSettingsHelper;
@@ -85,6 +93,7 @@ class AppSettingsService {
         $this->defaultSettings   = $defaultSettingsHelper;
         $this->nightlySettings   = $nightlySettingsHelper;
         $this->legacyApiSettings = $legacyApiSettingsHelper;
+        $this->domainSettings    = $domainSettingsHelper;
     }
 
     /**
@@ -111,6 +120,8 @@ class AppSettingsService {
                 return $this->nightlySettings->get($subKey);
             case 'legacy':
                 return $this->legacyApiSettings->get($subKey);
+            case 'domain':
+                return $this->domainSettings->get($subKey);
         }
 
         throw new ApiException('Unknown setting identifier', 400);
@@ -141,6 +152,8 @@ class AppSettingsService {
                 return $this->nightlySettings->set($subKey, $value);
             case 'legacy':
                 return $this->legacyApiSettings->set($subKey, $value);
+            case 'domain':
+                return $this->domainSettings->set($subKey, $value);
         }
 
         throw new ApiException('Unknown setting identifier', 400);
@@ -170,6 +183,8 @@ class AppSettingsService {
                 return $this->nightlySettings->reset($subKey);
             case 'legacy':
                 return $this->legacyApiSettings->reset($subKey);
+            case 'domain':
+                return $this->domainSettings->reset($subKey);
         }
 
         throw new ApiException('Unknown setting identifier', 400);
@@ -209,6 +224,10 @@ class AppSettingsService {
 
         if($scope === null || in_array('legacy', $scope)) {
             $settings = array_merge($settings, $this->legacyApiSettings->list());
+        }
+
+        if($scope === null || in_array('domain', $scope)) {
+            $settings = array_merge($settings, $this->domainSettings->list());
         }
 
         return $settings;

--- a/src/lib/Settings/AdminSettings.php
+++ b/src/lib/Settings/AdminSettings.php
@@ -11,6 +11,7 @@ use Exception;
 use OCA\Passwords\AppInfo\Application;
 use OCA\Passwords\Helper\Favicon\BestIconHelper;
 use OCA\Passwords\Helper\Image\ImagickHelper;
+use OCA\Passwords\Helper\Settings\DomainSettingsHelper;
 use OCA\Passwords\Helper\Preview\BrowshotPreviewHelper;
 use OCA\Passwords\Helper\Preview\ScreeenlyHelper;
 use OCA\Passwords\Helper\Preview\ScreenShotLayerHelper;
@@ -42,6 +43,11 @@ class AdminSettings implements ISettings {
     protected ConfigurationService $config;
 
     /**
+     * @var DomainSettingsHelper
+     */
+    protected DomainSettingsHelper $domainSettings;
+
+    /**
      * @var IRequest
      */
     protected IRequest $request;
@@ -69,19 +75,22 @@ class AdminSettings implements ISettings {
      * @param ConfigurationService $config
      * @param HelperService        $helperService
      * @param FileCacheService     $fileCacheService
+     * @param DomainSettingsHelper $domainSettings
      */
     public function __construct(
         IRequest $request,
         IURLGenerator $urlGenerator,
         ConfigurationService $config,
         HelperService $helperService,
-        FileCacheService $fileCacheService
+        FileCacheService $fileCacheService,
+        DomainSettingsHelper $domainSettings
     ) {
         $this->request          = $request;
         $this->config           = $config;
         $this->urlGenerator     = $urlGenerator;
         $this->helperService    = $helperService;
         $this->fileCacheService = $fileCacheService;
+        $this->domainSettings   = $domainSettings;
     }
 
     /**
@@ -89,6 +98,9 @@ class AdminSettings implements ISettings {
      */
     public function getForm(): TemplateResponse {
         return new TemplateResponse('passwords', 'admin/index', [
+            'defaultMapping'   => $this->domainSettings->getDefaultMappings(),
+            'customMapping'    => $this->config->getAppValue('domain/mapping/custom', "{\"data\":[]}"),
+            'useDefaultMapping'=> $this->config->getAppValue('domain/mapping/default/enabled', true),
             'imageServices'    => $this->getImageServices(),
             'wordsServices'    => $this->getWordsServices(),
             'faviconServices'  => $this->getFaviconServices(),

--- a/src/scss/admin.scss
+++ b/src/scss/admin.scss
@@ -111,6 +111,22 @@ section.section.passwords {
         }
     }
 
+    .area-table {
+        max-width: 600px;
+        max-height: 200px;
+        overflow-y: scroll;
+
+        table, tbody, tr, td {
+            width: 100%;
+        }
+
+        input[type=text] {
+            width    : calc(100% - 5px);
+            justify-self : left;
+            cursor       : pointer;
+        }
+    }
+
     @media (max-width : $mobile-width) {
         form {
             margin-bottom : 4em;

--- a/src/templates/admin/settings.php
+++ b/src/templates/admin/settings.php
@@ -246,6 +246,42 @@ $footerMessage = $l->t('%s, %s or %s? We\'ve got you covered!', $links);
             </div>
         <?php endforeach; ?>
     </form>
+
+    <form>
+        <h3>
+            <?php p($l->t('Domain mappings')); ?>
+            <span class="response success saved"><?php p($l->t('Saved')); ?></span>
+            <span class="response error"><?php p($l->t('Failed')); ?></span>
+        </h3>
+
+        <div class="area mappings">
+            <label for="passwords-urlmapping-default-enabled"><?php p($l->t('Include default domain list in search')); ?></label>
+            <input id="passwords-urlmapping-default-enabled" data-setting="domain.mapping.default.enabled" type="checkbox" <?=$_['useDefaultMapping'] ? 'checked':''?>>
+        </div>
+        <h4><?php p($l->t('Default domain mapping list')); ?></h4>
+        <div class="area-table">
+            <table>        
+                <tbody>
+                    <?php
+                        if (is_array($_['defaultMapping'])) {
+                            foreach ( $_['defaultMapping'] as $array_id => $value ) {
+                                echo '<tr><td><input value="' . implode(" ", array_values($value)) . '" type="text" disabled="true"></td></tr>' . "\n\n";
+                            }
+                        } else {
+                            echo '<tr><td colspan="2">Nothing to display :(</td></tr>';
+                        }
+                    ?>
+                </tbody>
+            </table>
+        </div>
+        <h4><?php p($l->t('Custom domain mapping list')); ?></h4>
+        <div class="area-table">
+            <?php echo '<div id="domain-mapping-custom" style="display: none;">' . $_['customMapping'] . '</div>'?>
+            <table>        
+                <tbody id="domain-mapping-table"></tbody>
+            </table>
+        </div>
+    </form>
 </section>
 <footer class="section passwords">
     <?php print_unescaped($footerMessage); ?>


### PR DESCRIPTION
This pull request adds a new api setting to the server scope. It is designed to mapp known domains with the same credentials so the password recommendations can work even better.

The new api setting is called `server.domain.mapping` and returns an nested array with content like this:
```
[
    ["apple.com", "icloud.com"],
    ["microsoft.com", "live.com", "office.com"...],
    ...
]
```

This new api setting can be configured in the admin settings of nextcloud. I tried to make the tables as responsive as possible. The following options are available:

- **Include default domain list in search** -> By default this is enabled and so the predefined domain mappings will be considered.
- **Default domain mapping list** -> This is a read only list to show which mappings are shipped in the default configuration. So the server admin has a full transparency.
- **Custom domain mapping list** -> In this table the server admin can add own mappings. E.g. when the company migrates from one domain to another because of a company fusion, the admin can make mappings so that the old passwords are also detected on the new domain.

The api setting `server.domain.mapping` retunrs an array which is the result of the settings inside the admin settings. It returns all custom mappings and also the default mappings when they are enabled in the admin settings. 
![image](https://user-images.githubusercontent.com/52607335/110232750-f8cf9700-7f1f-11eb-870e-77ae23b85e74.png)


A integration in the webextension will follow soon ;)

This is the first time I work on a php based project, so please be patient when the styling does not fit to 100% 😏. I tried my best to follow your design concept. If it does not fit please let me know how I can optimize it.