### PR TITLE
fix edited time only updating on password change

### DIFF
--- a/src/lib/Controller/Api/PasswordApiController.php
+++ b/src/lib/Controller/Api/PasswordApiController.php
@@ -241,7 +241,11 @@ class PasswordApiController extends AbstractObjectApiController {
         if($revision->getHash() !== $oldRevision->getHash()) {
             if($edited < 1 || $revision->getEdited() === $oldRevision->getEdited()) $revision->setEdited(time());
         } else {
-            $revision->setEdited($oldRevision->getEdited());
+            if($edited > 0) {
+                $revision->setEdited($edited);
+            } else {
+                $revision->setEdited($oldRevision->getEdited());
+            }
         }
 
         if($model->hasShares() || $model->getShareId() || !$model->isEditable()) {


### PR DESCRIPTION
I noticed that the edited time of changed passwords is only updating when the password itself is changed, as mentioned here https://github.com/marius-wieschollek/passwords-webextension/pull/167

This PR fixes this issue by allowing an update of the edited time also if no password hash was changed.