### PR TITLE
Add size parameter for higher resolution favicons

### DIFF
--- a/src/lib/Helper/Favicon/GoogleFaviconHelper.php
+++ b/src/lib/Helper/Favicon/GoogleFaviconHelper.php
@@ -41,7 +41,7 @@ class GoogleFaviconHelper extends AbstractFaviconHelper {
         $this->domain = $domain;
 
         return [
-            "https://www.google.com/s2/favicons?domain={$domain}",
+            "https://www.google.com/s2/favicons?domain={$domain}&sz=256",
             []
         ];
     }


### PR DESCRIPTION
Should provide higher resolution favicons, if available. When trying 512, it seemed to just return the default resolution of 16x16. So I set it to 256, this seems to return the highest available resolution of the image. Tried it on my Nextcloud instance, seems to work fine...