### PR TITLE
Removing frequently unsupported special characters

### DIFF
--- a/src/lib/Helper/Words/SpecialCharacterHelper.php
+++ b/src/lib/Helper/Words/SpecialCharacterHelper.php
@@ -36,8 +36,6 @@ class SpecialCharacterHelper {
 
     const REPLACE_SPECIAL
         = [
-            'e' => '€',
-            'E' => '€',
             'A' => '@',
             'a' => '@',
             's' => '$',

--- a/src/lib/Provider/Words/RandomCharactersProvider.php
+++ b/src/lib/Provider/Words/RandomCharactersProvider.php
@@ -22,11 +22,6 @@ use Random\Randomizer;
 class RandomCharactersProvider extends AbstractWordsProvider {
 
     const CHARACTER_LIST = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz';
-    const CHARACTERS_DE  = 'ÄäÖöÜüß';
-    const CHARACTERS_FR  = 'ÉèÊéÈêÂâÀàÔôÚúÛû';
-    const CHARACTERS_IT  = 'ÀàÈèÚú';
-    const CHARACTERS_ES  = 'ÁáÉéÍíÑñÓóÚú';
-    const CHARACTERS_PT  = 'ÁáÂâÀàÃãÇçÉéÊêÍíÔôÓôÕõÚÚ';
     const NUMBERS        = '0123456789';
     const SPECIAL        = '!?&%/()[]{}$€@-_';
 
@@ -54,7 +49,7 @@ class RandomCharactersProvider extends AbstractWordsProvider {
      */
     public function getWords(int $strength, bool $addNumbers, bool $addSpecial): ?array {
         $words      = [];
-        $characters = $this->getCharacterString();
+        $characters = self::CHARACTER_LIST;
         $strength   += 3;
         $length     = $strength === 3 ? 4:$strength;
 
@@ -75,27 +70,6 @@ class RandomCharactersProvider extends AbstractWordsProvider {
             'words'    => $words,
             'password' => $this->wordsArrayToPassword($words, $strength, $addNumbers, $addSpecial)
         ];
-    }
-
-    /**
-     * @return string
-     */
-    protected function getCharacterString(): string {
-        $characters = self::CHARACTER_LIST;
-        switch($this->langCode) {
-            case 'de':
-                return $characters.self::CHARACTERS_DE;
-            case 'fr':
-                return $characters.self::CHARACTERS_FR;
-            case 'it':
-                return $characters.self::CHARACTERS_IT;
-            case 'es':
-                return $characters.self::CHARACTERS_ES;
-            case 'pt':
-                return $characters.self::CHARACTERS_PT;
-        }
-
-        return $characters;
     }
 
     /**


### PR DESCRIPTION
Many Sites doesn't allow € and language specific characters, for compatibility sake the password generators shouldn't suggest them without the users ability to add or remove them. See #542 

Also we could add more special characters for the randomcharacterprovider
`!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~`
might be a good set of special characters
[source](https://owasp.org/www-community/password-special-characters)