### PR TITLE
Update ServiceApiController.php

### DIFF
--- a/src/lib/Controller/Api/ServiceApiController.php
+++ b/src/lib/Controller/Api/ServiceApiController.php
@@ -141,6 +141,7 @@ class ServiceApiController extends AbstractApiController {
     #[NoCSRFRequired]
     #[NoAdminRequired]
     public function getFavicon(string $domain, int $size = 32): FileDisplayResponse {
+        $domain = preg_replace("/\:([0-9]+)\$/",'',$domain);
         $file = $this->faviconService->getFavicon($domain, $size);
 
         return $this->createFileDisplayResponse($file);


### PR DESCRIPTION
The getFavicon throw an exception when the NextCloud service is not serving on the default port.  This bugfix remove the port numbers from the domain before prepare the real filename.