### PR TITLE
Fix 429 response in ServiceApiController.php

### DIFF
--- a/src/lib/Controller/Api/ServiceApiController.php
+++ b/src/lib/Controller/Api/ServiceApiController.php
@@ -142,7 +142,7 @@ class ServiceApiController extends AbstractApiController {
      */
     #[NoCSRFRequired]
     #[NoAdminRequired]
-    #[UserRateLimit(limit: 60, period: 60)]
+    #[UserRateLimit(limit: 500, period: 60)]
     public function getFavicon(string $domain, int $size = 32): FileDisplayResponse {
         $file = $this->faviconService->getFavicon($domain, $size);
 


### PR DESCRIPTION
In my setup I have ~ 300 passwords. During initial load most of the favicon requests are answered with a 429. 

In the documentation of nextcloud the description of Rate limit is "Rate limiting should be used on expensive or security sensitive functions (e.g. password resets) to increase the overall security of your application.". I think favicon is not expensive and security sensitive. So I believe, increasing the rate limit should not be a problem.

A rate limit of 500 should also be fine, because the browser itself is not requesting more then 5 per second.