### PR TITLE
Update HelperService.php to avoid Nextcloud log spam on PHP 8.4

### DIFF
--- a/src/lib/Services/HelperService.php
+++ b/src/lib/Services/HelperService.php
@@ -94,7 +94,7 @@ class HelperService {
      *
      * @return AbstractImageHelper
      */
-    public function getImageHelper(string $service = null): AbstractImageHelper {
+    public function getImageHelper(?string $service = null): AbstractImageHelper {
         if($service === null) $service = $this->config->getAppValue('service/images', self::IMAGES_AUTO);
 
         return match ($service) {
@@ -110,7 +110,7 @@ class HelperService {
      *
      * @return WordsProviderInterface
      */
-    public function getWordsHelper(string $service = null): WordsProviderInterface {
+    public function getWordsHelper(?string $service = null): WordsProviderInterface {
         if($service === null) $service = $this->config->getAppValue('service/words', HelperService::WORDS_AUTO);
 
         return match ($service) {
@@ -132,7 +132,7 @@ class HelperService {
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    public function getSecurityHelper(string $service = null): SecurityCheckProviderInterface {
+    public function getSecurityHelper(?string $service = null): SecurityCheckProviderInterface {
         $service = $this->config->getAppValue('service/security', $service ?? self::SECURITY_HIBP);
 
         return match ($service) {


### PR DESCRIPTION
The Nextcloud log is spammed with "Implicitly marking parameter $service as nullable is deprecated, the explicit nullable type must be used" at every cronjob run when using PHP 8.4. This patch applies the change PHP recommends.