### PR TITLE
Update AbstractSettingsHelper.php to avoid Nextcloud log spam on PHP 8.4

### DIFF
--- a/src/lib/Helper/AppSettings/AbstractSettingsHelper.php
+++ b/src/lib/Helper/AppSettings/AbstractSettingsHelper.php
@@ -202,7 +202,7 @@ abstract class AbstractSettingsHelper {
      * @return array
      * @throws ApiException
      */
-    protected function getGenericSetting(string $key, string $type = null): array {
+    protected function getGenericSetting(?string $key, string $type = null): array {
         $configKey = $this->getSettingKey($key);
         $default   = $this->getSettingDefault($key);
         $value     = $this->config->getAppValue($configKey, $default);


### PR DESCRIPTION
Apply the PHP recommended change to avoid "Implicitly marking parameter $type as nullable is deprecated, the explicit nullable type must be used" lines in the Nextcloud log at every cronjob run.