### PR TITLE
Some more PHP 8.4 convention updates

### DIFF
--- a/src/lib/Controller/Api/FolderApiController.php
+++ b/src/lib/Controller/Api/FolderApiController.php
@@ -141,7 +141,7 @@ class FolderApiController extends AbstractObjectApiController {
     public function update(
         string $id,
         string $label,
-        string $revision = null,
+        ?string $revision = null,
         string $parent = FolderService::BASE_FOLDER_UUID,
         string $cseKey = '',
         string $cseType = EncryptionService::DEFAULT_CSE_ENCRYPTION,

--- a/src/lib/Controller/Api/PasswordApiController.php
+++ b/src/lib/Controller/Api/PasswordApiController.php
@@ -195,7 +195,7 @@ class PasswordApiController extends AbstractObjectApiController {
     public function update(
         string $id,
         string $password,
-        string $revision = null,
+        ?string $revision = null,
         string $username = '',
         string $cseKey = '',
         string $cseType = EncryptionService::DEFAULT_CSE_ENCRYPTION,

--- a/src/lib/Controller/Api/SettingsApiController.php
+++ b/src/lib/Controller/Api/SettingsApiController.php
@@ -90,7 +90,7 @@ class SettingsApiController extends AbstractApiController {
     #[CORS]
     #[NoCSRFRequired]
     #[NoAdminRequired]
-    public function list(array $scopes = null): JSONResponse {
+    public function list(?array $scopes = null): JSONResponse {
         return $this->createJsonResponse(
             $this->settings->list($scopes)
         );

--- a/src/lib/Exception/ApiException.php
+++ b/src/lib/Exception/ApiException.php
@@ -28,7 +28,7 @@ class ApiException extends Exception {
      * @param int            $httpCode
      * @param Throwable|null $previous
      */
-    public function __construct(string $message = "", int $httpCode = 500, Throwable $previous = null) {
+    public function __construct(string $message = "", int $httpCode = 500, ?Throwable $previous = null) {
         parent::__construct($message, E_USER_ERROR, $previous);
         $this->httpCode = $httpCode;
     }

--- a/src/lib/Services/FileCacheService.php
+++ b/src/lib/Services/FileCacheService.php
@@ -68,7 +68,7 @@ class FileCacheService {
      * @throws NotPermittedException
      * @throws Exception
      */
-    public function getCache(string $cache = null): ISimpleFolder {
+    public function getCache(?string $cache = null): ISimpleFolder {
         $cache = $this->validateCacheName($cache);
 
         try {
@@ -137,7 +137,7 @@ class FileCacheService {
      * @return string
      * @throws Exception
      */
-    protected function validateCacheName(string $cache = null): string {
+    protected function validateCacheName(?string $cache = null): string {
         if($cache === null) return $this->defaultCache;
         if(!$this->hasCache($cache)) throw new Exception('Unknown Cache '.$cache);
 
@@ -147,7 +147,7 @@ class FileCacheService {
     /**
      * @param string|null $cache
      */
-    public function clearCache(string $cache = null): void {
+    public function clearCache(?string $cache = null): void {
         try {
             $this->getCache($cache)->delete();
             $class    = new ReflectionClass($this->appData);
@@ -174,7 +174,7 @@ class FileCacheService {
      *
      * @return bool
      */
-    public function isCacheEmpty(string $cache = null): bool {
+    public function isCacheEmpty(?string $cache = null): bool {
         try {
             $files = $this->getCache($cache)->getDirectoryListing();
 
@@ -192,7 +192,7 @@ class FileCacheService {
      *
      * @return bool
      */
-    public function hasFile(string $file, string $cache = null): bool {
+    public function hasFile(string $file, ?string $cache = null): bool {
         try {
             return $this->getCache($cache)->fileExists($file);
         } catch(Throwable $e) {
@@ -208,7 +208,7 @@ class FileCacheService {
      *
      * @return ISimpleFile
      */
-    public function getFile(string $file, string $cache = null): ?ISimpleFile {
+    public function getFile(string $file, ?string $cache = null): ?ISimpleFile {
         try {
             $cache = $this->getCache($cache);
 
@@ -227,7 +227,7 @@ class FileCacheService {
      *
      * @return ISimpleFile|null
      */
-    public function putFile(string $file, string $content, string $cache = null): ?ISimpleFile {
+    public function putFile(string $file, string $content, ?string $cache = null): ?ISimpleFile {
         try {
             $cache = $this->getCache($cache);
 

--- a/src/lib/Services/PasswordChangeUrlService.php
+++ b/src/lib/Services/PasswordChangeUrlService.php
@@ -202,7 +202,7 @@ class PasswordChangeUrlService {
      *
      * @return \CurlHandle
      */
-    protected function createCurlRequest(string $url, array $opts = null): \CurlHandle {
+    protected function createCurlRequest(string $url, ?array $opts = null): \CurlHandle {
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);


### PR DESCRIPTION
Explicitly declare nullable variables as per PHP 8.4 convention.