### PR TITLE
Faster sharing of password

### DIFF
--- a/src/lib/Cron/SynchronizeShares.php
+++ b/src/lib/Cron/SynchronizeShares.php
@@ -264,17 +264,13 @@ class SynchronizeShares extends AbstractTimedJob {
      * @throws Exception
      */
     protected function removeSharedAttribute(): void {
-        $passwords = $this->passwordService->findShared();
+        $passwords = $this->passwordService->findSharedPasswordsWithoutShares();
         $total     = 0;
 
         foreach($passwords as $password) {
-            $shares = $this->shareService->findBySourcePassword($password->getUuid());
-
-            if(empty($shares)) {
-                $password->setHasShares(false);
-                $this->passwordService->save($password);
-                $total++;
-            }
+            $password->setHasShares(false);
+            $this->passwordService->save($password);
+            $total++;
         }
 
         $this->logger->debugOrInfo(['Removed shared attribute from %s password(s)', $total], $total);

--- a/src/lib/Db/PasswordMapper.php
+++ b/src/lib/Db/PasswordMapper.php
@@ -87,6 +87,22 @@ class PasswordMapper extends AbstractMapper {
     }
 
     /**
+     * @return Password[]
+     */
+
+     public function findAllSharedPasswordsWithoutShares() {
+        $sql = $this->db->getQueryBuilder();
+        $sql->select('a.*')
+            ->from(static::TABLE_NAME, 'a')
+            ->leftJoin('a', ShareMapper::TABLE_NAME, 'b', 'a.`uuid` = b.`source_password`')
+            ->where(
+                $sql->expr()->eq('a.has_shares', $sql->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)),
+                $sql->expr()->isNull('b.id')
+            );
+        return $this->findEntities($sql);
+    }
+
+    /**
      * @param string $folderUuid
      *
      * @return Password[]

--- a/src/lib/Migration/Version20250930.php
+++ b/src/lib/Migration/Version20250930.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Passwords\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Class Version20250930
+ *
+ * @package OCA\Passwords\Migration
+ */
+class Version20250930 extends SimpleMigrationStep {
+    /**
+     * Human readable name of the migration step
+     *
+     * @return string
+     * @since 14.0.0
+     */
+    public function name(): string {
+        return 'Add indexes to make sharing faster';
+    }
+
+    /**
+     * Human readable description of the migration step
+     *
+     * @return string
+     * @since 14.0.0
+     */
+    public function description(): string {
+        return 'Add indexes for uuid field of passwords table and source_password field of shares table';
+    }
+
+    /**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('passwords_password');
+
+		if (!$table->hasIndex('pw_uuid_index')) {
+			$table->addIndex(['uuid'], 'pw_uuid_index');
+		}
+
+        $table = $schema->getTable('passwords_share');
+        if (!$table->hasIndex('share_source_password_index')) {
+            $table->addIndex(['source_password'], 'share_source_password_index');
+        }
+
+		return $schema;
+	}
+}

--- a/src/lib/Services/Object/PasswordService.php
+++ b/src/lib/Services/Object/PasswordService.php
@@ -78,6 +78,13 @@ class PasswordService extends AbstractModelService {
     public function findOrphanedTargetPasswords(): array {
         return $this->mapper->findAllOrphanedTargetPasswords();
     }
+    
+    /**
+     * @return Password[]
+     */
+    public function findSharedPasswordsWithoutShares(): array {
+        return $this->mapper->findAllSharedPasswordsWithoutShares();
+    }
 
     /**
      * @return Password


### PR DESCRIPTION
- Resolves https://github.com/marius-wieschollek/passwords/issues/695

### Technical details
- The method `removeSharedAttributes` runs for at least 10 minutes (sometimes more) without this fix on a system with about 10000 shared passwords
  - Most of the time, it isn't changing anything
  - It is the slowest method of all the ones run in `SynchronizeSharesJob` (sometimes `createNewShares` can be slow if a lot of passwords are created with `curl` but the cron route is not called - this is not a problem if passwords UI is the main consumer of the API)
- After the fix here to fetch passwords to remove shared attributes with a single indexed query, the method takes barely a second to run
