### PR TITLE
feat: allow users to share passwords via email

### DIFF
--- a/src/lib/Helper/Sharing/ShareUserListHelper.php
+++ b/src/lib/Helper/Sharing/ShareUserListHelper.php
@@ -146,7 +146,16 @@ class ShareUserListHelper {
     public function mapReceiverToUid(string $receiver): string {
         $receiver = trim($receiver);
         if($this->userManager->userExists($receiver)) return $receiver;
-
+        
+        //search by email
+        $usersByEmail = $this->userManager->getByEmail($receiver);
+        if(count($usersByEmail) === 1) {
+            $user = $usersByEmail[0];
+            if($user->isEnabled() && $user->getUID() !== $this->userId) {
+                return $user->getUID();
+            }
+        }
+        
         $partners = $this->getShareUsers($receiver);
         if(count($partners) === 1) return array_keys($partners)[0];
 


### PR DESCRIPTION
This MR improves the receiver resolution logic in the sharing flow by enabling user identification using email addresses in addition to UID.

Previously, sharing was only possible when the exact UID of a user was provided. With this change, users can now be resolved and shared with using their registered email address.

**Updated the mapReceiverToUid(string $receiver): string logic to:**

- Return UID directly if the receiver matches an existing user.
- Attempt lookup using email if no UID match is found.
- Resolve to UID when:
     - Exactly one user exists for the provided email.
     - The user is enabled.
     - The user is not the current user (self-sharing prevented).
- Fallback to share partner lookup if neither UID nor email match is found.