### PR TITLE
feat: Added bulk operations for handling many passwords/tags/folders …

### DIFF
--- a/src/js/Manager/SelectionManager.js
+++ b/src/js/Manager/SelectionManager.js
@@ -1,0 +1,114 @@
+import Vue from 'vue';
+
+/**
+ * Keeps track of which folders/tags/passwords are currently checked in a list view,
+ * so the header checkbox and every row can share one state without prop drilling.
+ */
+class SelectionManager {
+
+    constructor() {
+        this._state = Vue.observable(
+            {
+                folders  : [],
+                tags     : [],
+                passwords: [],
+                visible  : {folders: [], tags: [], passwords: []}
+            }
+        );
+    }
+
+    get folders() {
+        return this._state.folders;
+    }
+
+    get tags() {
+        return this._state.tags;
+    }
+
+    get passwords() {
+        return this._state.passwords;
+    }
+
+    get count() {
+        return this._state.folders.length + this._state.tags.length + this._state.passwords.length;
+    }
+
+    get active() {
+        return this.count !== 0;
+    }
+
+    get allSelected() {
+        let visible = this._state.visible,
+            total   = visible.folders.length + visible.tags.length + visible.passwords.length;
+
+        return total !== 0 && this.count === total;
+    }
+
+    /**
+     * Called by the list view whenever the currently loaded folders/tags/passwords change,
+     * so "select all" knows what "all" means right now.
+     *
+     * @param folders
+     * @param tags
+     * @param passwords
+     */
+    setVisible(folders, tags, passwords) {
+        this._state.visible = {folders, tags, passwords};
+        this._state.folders = this._state.folders.filter((f) => folders.indexOf(f) !== -1);
+        this._state.tags = this._state.tags.filter((t) => tags.indexOf(t) !== -1);
+        this._state.passwords = this._state.passwords.filter((p) => passwords.indexOf(p) !== -1);
+    }
+
+    isFolderSelected(folder) {
+        return this._state.folders.indexOf(folder) !== -1;
+    }
+
+    isTagSelected(tag) {
+        return this._state.tags.indexOf(tag) !== -1;
+    }
+
+    isPasswordSelected(password) {
+        return this._state.passwords.indexOf(password) !== -1;
+    }
+
+    toggleFolder(folder) {
+        this._state.folders = this._toggle(this._state.folders, folder);
+    }
+
+    toggleTag(tag) {
+        this._state.tags = this._toggle(this._state.tags, tag);
+    }
+
+    togglePassword(password) {
+        this._state.passwords = this._toggle(this._state.passwords, password);
+    }
+
+    /**
+     * Selects everything currently visible, or clears the selection if everything is already selected.
+     */
+    toggleAll() {
+        if(this.allSelected) {
+            this.clear();
+            return;
+        }
+
+        this._state.folders = [...this._state.visible.folders];
+        this._state.tags = [...this._state.visible.tags];
+        this._state.passwords = [...this._state.visible.passwords];
+    }
+
+    clear() {
+        this._state.folders = [];
+        this._state.tags = [];
+        this._state.passwords = [];
+    }
+
+    _toggle(list, item) {
+        let index = list.indexOf(item);
+        if(index === -1) return [...list, item];
+
+        return list.filter((entry) => entry !== item);
+    }
+}
+
+export default new SelectionManager();

--- a/src/js/Manager/TagManager.js
+++ b/src/js/Manager/TagManager.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import API from '@js/Helper/api';
 import Events from '@js/Classes/Events';
 import RandomColorService from '@js/Services/RandomColorService';
@@ -204,6 +205,21 @@ class TagManager {
             } else {
                 reject(tag);
             }
+        });
+    }
+
+    /**
+     * Opens a dialog to bulk add/remove tags on the given passwords.
+     *
+     * @param passwords
+     * @returns {Promise}
+     */
+    manageTags(passwords) {
+        return new Promise(async (resolve) => {
+            let ManageTagsDialog = await import(/* webpackChunkName: "ManageTags" */ '@vue/Dialog/ManageTags.vue'),
+                Dialog           = Vue.extend(ManageTagsDialog.default);
+
+            new Dialog({propsData: {passwords, resolve}}).$mount(UtilityService.popupContainer());
         });
     }
 

--- a/src/vue/Dialog/ManageTags.vue
+++ b/src/vue/Dialog/ManageTags.vue
@@ -1,0 +1,166 @@
+<!--
+  - @copyright 2023 Passwords App
+  -
+  - @author Marius David Wieschollek
+  - @license AGPL-3.0
+  -
+  - This file is part of the Passwords App
+  - created by Marius David Wieschollek.
+  -->
+
+<template>
+    <nc-modal
+            class="pw-manage-tags-dialog"
+            ref="window"
+            size="small"
+            :inlineActions="0"
+            v-on:close="close"
+            :container="container"
+            :title="t('Manage tags')">
+        <template #default>
+            <ul class="pw-manage-tags-list" v-if="!loading">
+                <li v-for="tag in tags" :key="tag.id" @click="toggleTag(tag)">
+                    <input type="checkbox"
+                           :checked="tagState(tag) === 'all'"
+                           :indeterminate.prop="tagState(tag) === 'some'"
+                           @click.stop="toggleTag(tag)">
+                    <tag-icon :fill-color="tag.color"/>
+                    <span>{{ tag.label }}</span>
+                </li>
+                <li class="pw-manage-tags-empty" v-if="tags.length === 0">{{ t('No tags found') }}</li>
+            </ul>
+            <nc-loading-icon class="pw-manage-tags-loading" :name="t('Loading')" :size="40" v-else/>
+        </template>
+    </nc-modal>
+</template>
+
+<script>
+    import Vue from 'vue';
+    import API from '@js/Helper/api';
+    import TagIcon from '@icon/Tag';
+    import NcModal from '@nc/NcModal.js';
+    import NcLoadingIcon from '@nc/NcLoadingIcon.js';
+    import ToastService from '@js/Services/ToastService';
+    import PasswordManager from '@js/Manager/PasswordManager';
+    import UtilityService from '@js/Services/UtilityService';
+
+    export default {
+        components: {TagIcon, NcModal, NcLoadingIcon},
+
+        props: {
+            passwords: {
+                type: Array
+            },
+            resolve  : {
+                type: Function
+            }
+        },
+
+        data() {
+            return {
+                tags     : [],
+                loading  : true,
+                container: UtilityService.popupContainer(true)
+            };
+        },
+
+        mounted() {
+            this.loadTags();
+        },
+
+        methods: {
+            async loadTags() {
+                await this.ensureTagsLoaded();
+                this.tags = UtilityService.sortApiObjectArray(await API.listTags(), 'label');
+                this.loading = false;
+            },
+            async ensureTagsLoaded() {
+                for(let password of this.passwords) {
+                    if(!password.tags) {
+                        let data = await API.showPassword(password.id, 'model+tags');
+                        Vue.set(password, 'tags', data.tags);
+                    }
+                }
+            },
+            passwordHasTag(password, tagId) {
+                let ids = Array.isArray(password.tags) ? password.tags:Object.keys(password.tags);
+                return ids.indexOf(tagId) !== -1;
+            },
+            tagState(tag) {
+                let count = 0;
+                for(let password of this.passwords) {
+                    if(this.passwordHasTag(password, tag.id)) count++;
+                }
+
+                if(count === 0) return 'none';
+                if(count === this.passwords.length) return 'all';
+                return 'some';
+            },
+            async toggleTag(tag) {
+                let add = this.tagState(tag) !== 'all';
+
+                for(let password of this.passwords) {
+                    let hasTag = this.passwordHasTag(password, tag.id);
+                    if(add && !hasTag) {
+                        Vue.set(password.tags, tag.id, tag);
+                        await PasswordManager.updatePassword(password);
+                    } else if(!add && hasTag) {
+                        Vue.delete(password.tags, tag.id);
+                        await PasswordManager.updatePassword(password);
+                    }
+                }
+
+                ToastService.success(add ? ['Added tag {tag}', {tag: tag.label}]:['Removed tag {tag}', {tag: tag.label}]);
+                this.$forceUpdate();
+            },
+            close() {
+                this.resolve();
+                this.$destroy();
+                if(this.$el.parentNode) this.$el.parentNode.removeChild(this.$el);
+            }
+        }
+    };
+</script>
+
+<style lang="scss">
+.pw-manage-tags-dialog {
+
+    .pw-manage-tags-list {
+        overflow-x : hidden;
+        padding    : .5rem 0 1rem;
+
+        li {
+            display     : flex;
+            align-items : center;
+            padding     : .5rem 1.5rem;
+            cursor      : pointer;
+
+            &:hover {
+                background-color : var(--color-background-hover);
+            }
+
+            input[type="checkbox"] {
+                margin-right : .75rem;
+            }
+
+            .tag-icon {
+                margin-right : .5rem;
+                flex-shrink  : 0;
+            }
+        }
+
+        .pw-manage-tags-empty {
+            cursor : default;
+            color  : var(--color-text-maxcontrast);
+
+            &:hover {
+                background-color : transparent;
+            }
+        }
+    }
+
+    .pw-manage-tags-loading {
+        height : 200px;
+    }
+}
+</style>

--- a/src/vue/Line/Folder.vue
+++ b/src/vue/Line/Folder.vue
@@ -5,6 +5,9 @@
          :data-folder-id="folder.id"
          :data-folder-title="folder.label"
          data-drop-type="folder">
+        <label class="select-item" @click.stop>
+            <input type="checkbox" :checked="isSelected" @change="toggleSelected">
+        </label>
         <star-icon class="favorite" data-item-action="favorite" fill-color="var(--color-element-warning)" @click.prevent.stop="favoriteAction" v-if="folder.favorite"/>
         <star-outline-icon class="favorite" data-item-action="favorite" fill-color="var(--color-placeholder-dark)" @click.prevent.stop="favoriteAction" v-else/>
         <div class="favicon" :style="{'background-image': 'url(' + folder.icon + ')'}" :title="folder.label">&nbsp;</div>
@@ -41,6 +44,7 @@
     import DragManager from '@js/Manager/DragManager';
     import FolderManager from '@js/Manager/FolderManager';
     import SearchManager from "@js/Manager/SearchManager";
+    import SelectionManager from "@js/Manager/SelectionManager";
     import ContextMenuService from '@js/Services/ContextMenuService';
     import StarIcon from "vue-material-design-icons/Star.vue";
     import StarOutlineIcon from "vue-material-design-icons/StarOutline.vue";
@@ -72,9 +76,13 @@
             dateTitle() {
                 return LocalisationService.translate('Last modified on {date}', {date: LocalisationService.formatDateTime(this.folder.edited)});
             },
+            isSelected() {
+                return SelectionManager.isFolderSelected(this.folder);
+            },
             className() {
                 let classNames = 'row folder';
 
+                if(this.isSelected) classNames += ' selected';
                 if(SearchManager.status.active) {
                     classNames += SearchManager.status.ids.indexOf(this.folder.id) !== -1 ? ' search-visible':' search-hidden';
                 }
@@ -92,6 +100,9 @@
                 this.folder.favorite = !this.folder.favorite;
                 FolderManager.updateFolder(this.folder)
                              .catch(() => { this.folder.favorite = !this.folder.favorite; });
+            },
+            toggleSelected() {
+                SelectionManager.toggleFolder(this.folder);
             },
             toggleMenu(state = null) {
                 if(state) {

--- a/src/vue/Line/Header.vue
+++ b/src/vue/Line/Header.vue
@@ -1,16 +1,36 @@
 <template>
     <div class="row header">
+        <label class="select-all" @click.stop title="Select All">
+            <input type="checkbox" :checked="allSelected" @change="toggleAll">
+        </label>
         <translate class="title" :class="titleClass" say="Name" @click="updateSorting('label')" title="Sort by name"/>
         <translate class="date" :class="dateClass" say="Modified" @click="updateSorting('edited')" title="Sort by modified date"/>
+        <dropdown-menu class="bulk-actions" v-if="hasSelection">
+            <ul slot="items">
+                <li v-if="canMove">
+                    <translate tag="a" href="#" @click.prevent="moveSelection" icon="external-link" say="Move"/>
+                </li>
+                <li>
+                    <translate tag="a" href="#" @click.prevent="deleteSelection" icon="trash" say="Delete"/>
+                </li>
+            </ul>
+        </dropdown-menu>
     </div>
 </template>
 
 <script>
     import Translate from "@vue/Components/Translate";
+    import DropdownMenu from "@vc/DropdownMenu";
+    import SelectionManager from "@js/Manager/SelectionManager";
+    import FolderManager from "@js/Manager/FolderManager";
+    import TagManager from "@js/Manager/TagManager";
+    import PasswordManager from "@js/Manager/PasswordManager";
+    import MessageService from "@js/Services/MessageService";
 
     export default {
         components: {
-            Translate
+            Translate,
+            DropdownMenu
         },
 
         props: {
@@ -28,6 +48,15 @@
             },
             dateClass() {
                 return this.getClass('edited');
+            },
+            allSelected() {
+                return SelectionManager.allSelected;
+            },
+            hasSelection() {
+                return SelectionManager.active;
+            },
+            canMove() {
+                return SelectionManager.folders.length !== 0 || SelectionManager.passwords.length !== 0;
             }
         },
 
@@ -44,6 +73,37 @@
                 } else {
                     this.$emit('updateSorting', {field: field, ascending: true});
                 }
+            },
+            toggleAll() {
+                SelectionManager.toggleAll();
+            },
+            deleteSelection() {
+                let count = SelectionManager.count;
+
+                MessageService
+                    .confirm(['Do you want to delete {count} selected items?', {count}], 'Delete items')
+                    .then(async () => {
+                        for(let folder of SelectionManager.folders) await FolderManager.deleteFolder(folder, false);
+                        for(let tag of SelectionManager.tags) await TagManager.deleteTag(tag, false);
+                        for(let password of SelectionManager.passwords) await PasswordManager.deletePassword(password, false);
+
+                        SelectionManager.clear();
+                    })
+                    .catch(() => {});
+            },
+            async moveSelection() {
+                let target_folder = await FolderManager.selectFolder(); 
+                let target_folder_id = target_folder.id
+
+                for(let folder of SelectionManager.folders) {
+                    if(folder.id === target) continue;
+                    await FolderManager.moveFolder(folder, target_folder_id);
+                }
+                for(let password of SelectionManager.passwords) {
+                    await PasswordManager.movePassword(password, target_folder_id);
+                }
+
+                SelectionManager.clear();
             }
         }
     };
@@ -58,15 +118,56 @@
                 -moz-user-select    : none;
                 -ms-user-select     : none;
                 user-select         : none;
+                display             : flex;
+                align-items         : center;
+
+                .select-all {
+                    width        : 40px;
+                    flex-shrink  : 0;
+                    cursor       : pointer;
+                    line-height  : 0;
+                    padding-left : 10px;
+                }
 
                 .title {
                     padding-left : 99px;
+                    flex-grow    : 1;
                 }
 
                 .date {
                     color     : $color-grey-dark;
                     width     : auto;
                     min-width : 85px;
+                }
+
+                .bulk-actions {
+                    margin-right : 10px;
+
+                    .popovermenu {
+                        background-color : var(--color-main-background);
+                        border            : 1px solid var(--color-border);
+                        box-shadow        : 0 1px 5px var(--color-box-shadow);
+                        border-radius     : var(--border-radius);
+                        top               : auto;
+
+                        li {
+                            font-size   : 0.9rem;
+                            line-height : 2.5rem;
+                            white-space : nowrap;
+                            cursor      : pointer;
+                            padding     : 0 .75rem;
+
+                            a {
+                                display     : flex;
+                                align-items : center;
+                                color       : var(--color-main-text);
+                            }
+
+                            &:hover {
+                                background-color : var(--color-background-hover);
+                            }
+                        }
+                    }
                 }
 
                 .asc::after,

--- a/src/vue/Line/Header.vue
+++ b/src/vue/Line/Header.vue
@@ -3,34 +3,69 @@
         <label class="select-all" @click.stop title="Select All">
             <input type="checkbox" :checked="allSelected" @change="toggleAll">
         </label>
-        <translate class="title" :class="titleClass" say="Name" @click="updateSorting('label')" title="Sort by name"/>
-        <translate class="date" :class="dateClass" say="Modified" @click="updateSorting('edited')" title="Sort by modified date"/>
-        <dropdown-menu class="bulk-actions" v-if="hasSelection">
-            <ul slot="items">
-                <li v-if="canMove">
-                    <translate tag="a" href="#" @click.prevent="moveSelection" icon="external-link" say="Move"/>
-                </li>
-                <li>
-                    <translate tag="a" href="#" @click.prevent="deleteSelection" icon="trash" say="Delete"/>
-                </li>
-            </ul>
-        </dropdown-menu>
+        <div class="selection-toolbar" v-if="hasSelection">
+            <span class="selection-count">{{ selectionCountLabel }}</span>
+            <nc-button type="tertiary" @click="favoriteSelection" v-if="canFavorite">
+                <template #icon>
+                    <star-icon v-if="allFavorites"/>
+                    <star-outline-icon v-else/>
+                </template>
+                {{ allFavorites ? t('Remove from favorites') : t('Add to favorites') }}
+            </nc-button>
+            <nc-button type="tertiary" @click="manageTagsSelection" v-if="canManageTags">
+                <template #icon>
+                    <tag-icon/>
+                </template>
+                {{ t('Manage tags') }}
+            </nc-button>
+            <nc-button type="tertiary" @click="moveSelection" v-if="canMove">
+                <template #icon>
+                    <folder-move-icon/>
+                </template>
+                {{ t('Move') }}
+            </nc-button>
+            <nc-actions class="selection-more" :force-menu="true">
+                <nc-action-button @click="deleteSelection" :close-after-click="true">
+                    <template #icon>
+                        <trash-can-icon/>
+                    </template>
+                    {{ t('Delete') }}
+                </nc-action-button>
+            </nc-actions>
+        </div>
+        <template v-else>
+            <translate class="title" :class="titleClass" say="Name" @click="updateSorting('label')" title="Sort by name"/>
+            <translate class="date" :class="dateClass" say="Modified" @click="updateSorting('edited')" title="Sort by modified date"/>
+        </template>
     </div>
 </template>
 
 <script>
     import Translate from "@vue/Components/Translate";
-    import DropdownMenu from "@vc/DropdownMenu";
     import SelectionManager from "@js/Manager/SelectionManager";
     import FolderManager from "@js/Manager/FolderManager";
     import TagManager from "@js/Manager/TagManager";
     import PasswordManager from "@js/Manager/PasswordManager";
     import MessageService from "@js/Services/MessageService";
+    import NcButton from "@nc/NcButton.js";
+    import StarIcon from "@icon/Star";
+    import StarOutlineIcon from "@icon/StarOutline";
+    import TagIcon from "@icon/Tag";
+    import FolderMoveIcon from "@icon/FolderMove";
+    import TrashCanIcon from "@icon/TrashCan";
+    import LocalisationService from "@js/Services/LocalisationService";
 
     export default {
         components: {
             Translate,
-            DropdownMenu
+            NcButton,
+            StarIcon,
+            StarOutlineIcon,
+            TagIcon,
+            FolderMoveIcon,
+            TrashCanIcon,
+            'nc-actions'      : () => import(/* webpackChunkName: "NcActions" */ '@nc/NcActions.js'),
+            'nc-action-button': () => import(/* webpackChunkName: "NcActionButton" */ '@nc/NcActionButton.js')
         },
 
         props: {
@@ -55,8 +90,20 @@
             hasSelection() {
                 return SelectionManager.active;
             },
+            selectionCountLabel() {
+                return LocalisationService.translate('{count} selected', {count: SelectionManager.count});
+            },
             canMove() {
                 return SelectionManager.folders.length !== 0 || SelectionManager.passwords.length !== 0;
+            },
+            canFavorite() {
+                return SelectionManager.passwords.length !== 0;
+            },
+            canManageTags() {
+                return SelectionManager.passwords.length !== 0;
+            },
+            allFavorites() {
+                return SelectionManager.passwords.every((password) => password.favorite === true);
             }
         },
 
@@ -92,11 +139,11 @@
                     .catch(() => {});
             },
             async moveSelection() {
-                let target_folder = await FolderManager.selectFolder(); 
-                let target_folder_id = target_folder.id
+                let target_folder = await FolderManager.selectFolder(),
+                    target_folder_id = target_folder.id;
 
                 for(let folder of SelectionManager.folders) {
-                    if(folder.id === target) continue;
+                    if(folder.id === target_folder_id || folder.parent === target_folder_id) continue;
                     await FolderManager.moveFolder(folder, target_folder_id);
                 }
                 for(let password of SelectionManager.passwords) {
@@ -104,6 +151,18 @@
                 }
 
                 SelectionManager.clear();
+            },
+            async favoriteSelection() {
+                let makeFavorite = !this.allFavorites;
+
+                for(let password of SelectionManager.passwords) {
+                    if(password.favorite === makeFavorite) continue;
+                    password.favorite = makeFavorite;
+                    await PasswordManager.updatePassword(password);
+                }
+            },
+            manageTagsSelection() {
+                TagManager.manageTags(SelectionManager.passwords);
             }
         }
     };
@@ -127,6 +186,36 @@
                     cursor       : pointer;
                     line-height  : 0;
                     padding-left : 10px;
+
+                    input[type="checkbox"] {
+                        appearance         : none;
+                        -webkit-appearance : none;
+                        width              : 40px;
+                        height             : 40px;
+                        margin             : 0;
+                        border             : 4px solid var(--color-primary-element);
+                        border-radius      : 8px;
+                        background-color   : transparent;
+                        vertical-align     : middle;
+                        cursor             : pointer;
+                        position           : relative;
+
+                        &:checked {
+                            background-color : var(--color-primary-element);
+
+                            &::after {
+                                content      : '';
+                                position     : absolute;
+                                left         : 5px;
+                                top          : 1px;
+                                width        : 5px;
+                                height       : 10px;
+                                border       : solid var(--color-primary-element-text);
+                                border-width : 0 2px 2px 0;
+                                transform    : rotate(45deg);
+                            }
+                        }
+                    }
                 }
 
                 .title {
@@ -140,33 +229,24 @@
                     min-width : 85px;
                 }
 
-                .bulk-actions {
-                    margin-right : 10px;
+                .selection-toolbar {
+                    display      : flex;
+                    align-items  : center;
+                    flex-grow    : 1;
+                    gap          : .5rem;
+                    padding-right: 10px;
+                    font-size    : 0.875rem;
 
-                    .popovermenu {
-                        background-color : var(--color-main-background);
-                        border            : 1px solid var(--color-border);
-                        box-shadow        : 0 1px 5px var(--color-box-shadow);
-                        border-radius     : var(--border-radius);
-                        top               : auto;
+                    .selection-count {
+                        font-weight  : bold;
+                        font-size    : 0.875rem;
+                        color        : var(--color-main-text);
+                        margin-right : .5rem;
+                        white-space  : nowrap;
+                    }
 
-                        li {
-                            font-size   : 0.9rem;
-                            line-height : 2.5rem;
-                            white-space : nowrap;
-                            cursor      : pointer;
-                            padding     : 0 .75rem;
-
-                            a {
-                                display     : flex;
-                                align-items : center;
-                                color       : var(--color-main-text);
-                            }
-
-                            &:hover {
-                                background-color : var(--color-background-hover);
-                            }
-                        }
+                    .selection-more {
+                        margin-left : auto;
                     }
                 }
 

--- a/src/vue/Line/Password.vue
+++ b/src/vue/Line/Password.vue
@@ -6,6 +6,9 @@
          :class="className"
          :data-password-id="password.id"
          :data-password-title="password.label">
+        <label class="select-item" @click.stop>
+            <input type="checkbox" :checked="isSelected" @change="toggleSelected">
+        </label>
         <star-icon class="favorite" data-item-action="favorite" fill-color="var(--color-element-warning)" @click.prevent.stop="favoriteAction" v-if="password.favorite"/>
         <star-outline-icon class="favorite" data-item-action="favorite" fill-color="var(--color-placeholder-dark)" @click.prevent.stop="favoriteAction" v-else/>
         <favicon class="favicon" :domain="password.website" :title="getTitle" v-if="isVisible"/>
@@ -113,6 +116,7 @@
     import SettingsService from '@js/Services/SettingsService';
     import Favicon from "@vc/Favicon";
     import SearchManager from "@js/Manager/SearchManager";
+    import SelectionManager from "@js/Manager/SelectionManager";
     import ContextMenuService from "@js/Services/ContextMenuService";
     import TrashCanIcon from "@icon/TrashCan";
     import OpenInNewIcon from "@icon/OpenInNew";
@@ -234,10 +238,14 @@
             isVisible() {
                 return !SearchManager.status.active || SearchManager.status.ids.indexOf(this.password.id) !== -1;
             },
+            isSelected() {
+                return SelectionManager.isPasswordSelected(this.password);
+            },
             className() {
                 let classNames = 'row password';
 
                 if(this.detailsActive) classNames += ' details-open';
+                if(this.isSelected) classNames += ' selected';
                 if(SearchManager.status.active) {
                     classNames += SearchManager.status.ids.indexOf(this.password.id) !== -1 ? ' search-visible':' search-hidden';
                 }
@@ -328,6 +336,9 @@
             },
             favoriteAction() {
                 this.actions.favorite();
+            },
+            toggleSelected() {
+                SelectionManager.togglePassword(this.password);
             },
             printAction() {
                 this.actions.print();
@@ -432,6 +443,14 @@
             border-bottom : 1px solid var(--color-border);
             cursor        : pointer;
             display       : flex;
+
+            .select-item {
+                line-height : 50px;
+                width       : 40px;
+                flex-shrink : 0;
+                cursor      : pointer;
+                text-align  : center;
+            }
 
             .favorite {
                 line-height : 50px;
@@ -612,7 +631,8 @@
                 background-color : var(--color-background-hover);
             }
 
-            &.details-open {
+            &.details-open,
+            &.selected {
                 background-color : var(--color-primary-light);
             }
 

--- a/src/vue/Line/Password.vue
+++ b/src/vue/Line/Password.vue
@@ -450,6 +450,36 @@
                 flex-shrink : 0;
                 cursor      : pointer;
                 text-align  : center;
+
+                input[type="checkbox"] {
+                    appearance         : none;
+                    -webkit-appearance : none;
+                    width              : 20px;
+                    height             : 20px;
+                    margin             : 0;
+                    border             : 2px solid var(--color-primary-element);
+                    border-radius      : 4px;
+                    background-color   : transparent;
+                    vertical-align     : middle;
+                    cursor             : pointer;
+                    position           : relative;
+
+                    &:checked {
+                        background-color : var(--color-primary-element);
+
+                        &::after {
+                            content      : '';
+                            position     : absolute;
+                            left         : 5px;
+                            top          : 1px;
+                            width        : 5px;
+                            height       : 10px;
+                            border       : solid var(--color-primary-element-text);
+                            border-width : 0 2px 2px 0;
+                            transform    : rotate(45deg);
+                        }
+                    }
+                }
             }
 
             .favorite {

--- a/src/vue/Line/Tag.vue
+++ b/src/vue/Line/Tag.vue
@@ -1,5 +1,8 @@
 <template>
     <div :class="className" @click="openAction($event)" :data-tag-id="tag.id" :data-tag-title="tag.label">
+        <label class="select-item" @click.stop>
+            <input type="checkbox" :checked="isSelected" @change="toggleSelected">
+        </label>
         <star-icon class="favorite" data-item-action="favorite" fill-color="var(--color-element-warning)" @click.prevent.stop="favoriteAction" v-if="tag.favorite"/>
         <star-outline-icon class="favorite" data-item-action="favorite" fill-color="var(--color-placeholder-dark)" @click.prevent.stop="favoriteAction" v-else/>
         <div class="favicon fa fa-tag" :style="{color: this.tag.color}" :title="tag.label"></div>
@@ -32,6 +35,7 @@
     import Translate from '@vc/Translate';
     import TagManager from '@js/Manager/TagManager';
     import SearchManager from "@js/Manager/SearchManager";
+    import SelectionManager from "@js/Manager/SelectionManager";
     import ContextMenuService from '@js/Services/ContextMenuService';
     import StarIcon from "@icon/Star";
     import StarOutlineIcon from "@icon/StarOutline";
@@ -63,9 +67,13 @@
             dateTitle() {
                 return LocalisationService.translate('Last modified on {date}', {date: LocalisationService.formatDateTime(this.tag.edited)});
             },
+            isSelected() {
+                return SelectionManager.isTagSelected(this.tag);
+            },
             className() {
                 let classNames = 'row tag';
 
+                if(this.isSelected) classNames += ' selected';
                 if(SearchManager.status.active) {
                     classNames += SearchManager.status.ids.indexOf(this.tag.id) !== -1 ? ' search-visible':' search-hidden';
                 }
@@ -83,6 +91,9 @@
                 this.tag.favorite = !this.tag.favorite;
                 TagManager.updateTag(this.tag)
                           .catch(() => { this.tag.favorite = !this.tag.favorite; });
+            },
+            toggleSelected() {
+                SelectionManager.toggleTag(this.tag);
             },
             toggleMenu(state = null) {
                 if(state) {

--- a/src/vue/Section/BaseSection.vue
+++ b/src/vue/Section/BaseSection.vue
@@ -45,6 +45,7 @@
     import FooterLine from '@vue/Line/Footer';
     import PasswordLine from '@vue/Line/Password';
     import SearchManager from '@js/Manager/SearchManager';
+    import SelectionManager from '@js/Manager/SelectionManager';
     import UtilityService from "@js/Services/UtilityService";
     import SettingsService from '@js/Services/SettingsService';
     import LocalisationService from "@js/Services/LocalisationService";
@@ -73,7 +74,7 @@
                 ui       : {
                     showTags: SettingsService.get('client.ui.list.tags.show', false) && window.innerWidth > 360
                 },
-                search   : SearchManager.status
+                search   : SearchManager.status,
             };
         },
 
@@ -86,6 +87,7 @@
         beforeDestroy() {
             Events.off('data.changed', this.refreshView);
             SearchManager.clearDatabase();
+            SelectionManager.clear();
         },
 
         computed: {
@@ -172,14 +174,17 @@
             passwords(passwords) {
                 let db = {passwords, folders: this.folders, tags: this.tags};
                 SearchManager.setDatabase(db);
+                SelectionManager.setVisible(this.folders, this.tags, passwords);
             },
             tags(tags) {
                 let db = {passwords: this.passwords, folders: this.folders, tags};
                 SearchManager.setDatabase(db);
+                SelectionManager.setVisible(this.folders, tags, this.passwords);
             },
             folders(folders) {
                 let db = {passwords: this.passwords, folders, tags: this.tags};
                 SearchManager.setDatabase(db);
+                SelectionManager.setVisible(folders, this.tags, this.passwords);
             }
         }
     };


### PR DESCRIPTION
#610 

- This is a feature request allowing users to move, and delete in bulk.
- Logically it iterates over API instead of calling one "bulk" api

### Checklist
- [x] My commits are [signed](https://git.mdns.eu/nextcloud/passwords/wikis/Developers/Contributing/Verify-Git-Commits)
- [x] I guarantee that this code qualifies as a product of my own work and copyrightable under the [LICENSE](https://github.com/marius-wieschollek/passwords/blob/master/LICENSE).
      _Code created in significant parts by AI is not allowed._

### Description
This PR adds the functionality to be able to bulk move and delete passwords, tags and folders all at once. The current implementation is doing an iterative process of making requests for each of the elements that was selected. A much more clean and better approach should be to implement a dedicated API for this purpose.
I'm not familiar with PHP that much, hence wanted to implement a baseline structure such that I can quickly hot swap the API when I created it.
