### PR TITLE
Share passwords with a group

### DIFF
--- a/.weblate/ar/messages.json
+++ b/.weblate/ar/messages.json
@@ -3640,9 +3640,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "سيُعوق التشفير من النهاية إلى الثانية على أي كلمة سر عندما يُتقاسمها."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "والتقاسم مع المجموعات غير مدعوم. وبدلا من ذلك، ستتقاسم كل كلمة سر مع كل عضو من أعضاء المجموعة الحاليين على حدة."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "مجموعة المستخدمين"
     }

--- a/.weblate/ca/messages.json
+++ b/.weblate/ca/messages.json
@@ -3539,9 +3539,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "L' encriptatge final a final es deshabilitarà en qualsevol contrasenya quan es comparteixi."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "No es permet compartir amb grups. En comptes d' això, les contrasenyes seran compartides amb cada membre del grup actual individualment."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Grup d' usuaris"
     }

--- a/.weblate/cs/messages.json
+++ b/.weblate/cs/messages.json
@@ -3633,9 +3633,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "End- to - End šifrování bude při sdílení vypnuto na libovolném heslu."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Sdílení se skupinami není podporováno. Místo toho budou hesla sdílena s každým současným členem skupiny jednotlivě."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Uživatelská skupina"
     }

--- a/.weblate/da/messages.json
+++ b/.weblate/da/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "End-to-End-kryptering deaktiveres for alle adgangskoder, når de deles."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Deling med grupper understøttes ikke. I stedet vil adgangskoderne blive delt med hvert enkelt nuværende gruppemedlem individuelt."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Brugergruppe"
     }

--- a/.weblate/de/messages.json
+++ b/.weblate/de/messages.json
@@ -3634,9 +3634,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Ende-zu-Ende Verschlüsselung wird für jedes zu teilende Passwort deaktiviert."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Teilen mit Gruppen ist nicht möglich. Stattdessen werden die Passwörter mit jedem Gruppenmitglied einzeln geteilt."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Benutzergruppe"
     }

--- a/.weblate/de_DE/messages.json
+++ b/.weblate/de_DE/messages.json
@@ -3634,9 +3634,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Ende-zu-Ende Verschlüsselung wird für jedes zu teilende Passwort deaktiviert."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Teilen mit Gruppen ist nicht möglich. Stattdessen werden die Passwörter mit jedem Gruppenmitglied einzeln geteilt."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Benutzergruppe"
     }

--- a/.weblate/el/messages.json
+++ b/.weblate/el/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Η κρυπτογράφηση από το τέλος στο τέλος θα απενεργοποιηθεί σε οποιονδήποτε κωδικό πρόσβασης όταν μοιραστείτε."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Η κοινή χρήση με ομάδες δεν υποστηρίζεται. Αντ' αυτού, οι κωδικοί πρόσβασης θα μοιράζονται με κάθε τρέχον μέλος της ομάδας ξεχωριστά."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Ομάδα χρηστών"
     }

--- a/.weblate/en/messages.json
+++ b/.weblate/en/messages.json
@@ -3563,10 +3563,6 @@
         "message": "End-to-End encryption will be disabled on any password when shared.",
         "description": "Warning in the passwords batch share dialog if the user has selected items that can't be shared"
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Sharing with groups is not supported. Instead, the passwords will be shared with each current group member individually.",
-        "description": "Warning in the passwords batch share dialog if the user has selected items that can't be shared"
-    },
     "frontend-BatchActionShareSelectUsersLabel": {
         "message": "Select users to share with",
         "description": "Label of the user selection field in the batch share dialog"
@@ -3704,5 +3700,41 @@
     "frontend-BatchShareSubnameGroup": {
         "message": "User group",
         "description": "Subtext in the user selection dropdown in the batch sharing dialog for group entries"
+    },
+    "frontend-ShareTabSearchPlaceholder": {
+        "message": "Search user or group",
+        "description": "Placeholder of the recipient selection field in the share tab of the password details"
+    },
+    "frontend-ShareTabSelectRecipientLabel": {
+        "message": "Share with user or group",
+        "description": "Label of the recipient selection field in the share tab of the password details"
+    },
+    "frontend-ShareTabGroupShareHint": {
+        "message": "Shared with all members of this group",
+        "description": "Tooltip of a group entry in the list of shares in the share tab of the password details"
+    },
+    "frontend-DeleteShareErrorGroupShare": {
+        "message": "\"$RECIPIENT$\" still has \"$PASSWORD$\" because it is shared with a group they are a member of. Remove them from the group or delete the group share.",
+        "description": "Message in the batch share dialog when the access of a recipient can not be revoked because a group share gives them the password",
+        "placeholders": {
+            "password": {
+                "content": "$1",
+                "description": "Name of the password"
+            },
+            "recipient": {
+                "content": "$2",
+                "description": "Name of the recipient"
+            }
+        }
+    },
+    "frontend-ShareTabGroupDoesNotExist": {
+        "message": "The group \"$GROUP$\" does not exist.",
+        "description": "Error message in the share tab of the password details if the selected group can not be found",
+        "placeholders": {
+            "group": {
+                "content": "$1",
+                "description": "Name of the group"
+            }
+        }
     }
 }

--- a/.weblate/es/messages.json
+++ b/.weblate/es/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Encriptación de extremo a extremo se deshabilitará en cualquier contraseña cuando se comparta."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Compartir con grupos no es compatible. En cambio, las contraseñas se compartirán con cada miembro del grupo actual individualmente."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Grupo de usuarios"
     }

--- a/.weblate/eu/messages.json
+++ b/.weblate/eu/messages.json
@@ -3541,9 +3541,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Amaierako enkriptatzea desgaitu egingo da pasahitzarekin partekatuz gero."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Taldeekin partekatzea ez dago onartuta. Horren ordez, pasahitzak uneko taldeko kide bakoitzarekin partekatuko dira banaka."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Erabiltzaile taldea"
     }

--- a/.weblate/fi/messages.json
+++ b/.weblate/fi/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Loppusalaus poistetaan millä tahansa salasanalla, kun se on jaettu."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Ryhmien kanssa tehtävää yhteistyötä ei tueta. Sen sijaan salasanat jaetaan kunkin nykyisen ryhmän jäsenen kanssa erikseen."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Käyttäjäryhmä"
     }

--- a/.weblate/fr/messages.json
+++ b/.weblate/fr/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Le chiffrement de bout en bout sera désactivé sur tout mot de passe partagé."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Le partage avec les groupes n'est pas pris en charge. Au lieu de cela, les mots de passe seront partagés avec chaque membre du groupe actuel individuellement."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Groupe d'utilisateurs"
     }

--- a/.weblate/gl/messages.json
+++ b/.weblate/gl/messages.json
@@ -3648,9 +3648,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "O cifrado de extremo a extremo desactivarase en calquera contrasinal cando se comparta."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Non se permite compartir con grupos. No canto diso, os contrasinais compartiránse de xeito individual con cada un dos membros actuais do grupo."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Grupo de usuarios"
     }

--- a/.weblate/hu/messages.json
+++ b/.weblate/hu/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Az End- to- End titkosítást a megosztott jelszavakra letiltjuk."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "A csoportokkal való megosztás nem támogatott. Ehelyett a jelszavakat minden jelenlegi csoporttaggal egyenként osztják meg."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Felhasználócsoport"
     }

--- a/.weblate/id/messages.json
+++ b/.weblate/id/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "End-to-End enkripsi akan dinonaktifkan pada password apapun ketika terbagi."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Berbagi dengan grup tidak didukung. Sebaliknya, password akan dibagi dengan masing-masing anggota kelompok saat ini secara individual."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Grup pengguna"
     }

--- a/.weblate/it/messages.json
+++ b/.weblate/it/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "La crittografia end-to-End sarà disabilitata su qualsiasi password quando condivisa."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "La condivisione con i gruppi non è supportata. Invece, le password saranno condivise con ogni membro del gruppo corrente singolarmente."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Gruppo utente"
     }

--- a/.weblate/lt/messages.json
+++ b/.weblate/lt/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "@ info: whatsthis."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Bendravimas su grupėmis neremiamas. Vietoj to slaptažodžiais bus dalijamasi su kiekvienu dabartiniu grupės nariu atskirai."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Vartotojo grupė"
     }

--- a/.weblate/nb_NO/messages.json
+++ b/.weblate/nb_NO/messages.json
@@ -3643,9 +3643,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "End-to-End kryptering vil bli deaktivert på ethvert passord når delt."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Deling med grupper støttes ikke. I stedet vil passordene deles med hvert gjeldende gruppemedlem individuelt."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Brukergruppe"
     }

--- a/.weblate/nl/messages.json
+++ b/.weblate/nl/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "End-to-End encryptie zal worden uitgeschakeld op elk wachtwoord wanneer gedeeld."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Delen met groepen wordt niet ondersteund. In plaats daarvan worden de wachtwoorden gedeeld met elk huidig groepslid afzonderlijk."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Gebruikersgroep"
     }

--- a/.weblate/pl/messages.json
+++ b/.weblate/pl/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Szyfrowanie end- to- End zostanie wyłączone na dowolnym haśle podczas udostępniania."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Dzielenie się z grupami nie jest wspierane. Zamiast tego hasła będą udostępniane każdemu obecnemu członkowi grupy indywidualnie."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Grupa użytkowników"
     }

--- a/.weblate/pt/messages.json
+++ b/.weblate/pt/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "A criptografia de ponta a ponta será desabilitada em qualquer senha quando compartilhada."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Partilhar com grupos não é suportado. Em vez disso, as senhas serão compartilhadas com cada membro do grupo atual individualmente."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Grupo de usuários"
     }

--- a/.weblate/pt_BR/messages.json
+++ b/.weblate/pt_BR/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "A criptografia de ponta a ponta será desativada em qualquer senha quando compartilhada."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Compartilhar com grupos não é suportado. Em vez disso, as senhas serão compartilhadas com cada membro do grupo."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Grupo de usuários"
     }

--- a/.weblate/ru/messages.json
+++ b/.weblate/ru/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Окончательное шифрование будет отключено на любом пароле при совместном использовании."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Обмен информацией с группами не поддерживается. Вместо этого пароли будут передаваться каждому текущему члену группы индивидуально."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Группа пользователей"
     }

--- a/.weblate/sk/messages.json
+++ b/.weblate/sk/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "End-to- End šifrovanie bude vypnuté na akomkoľvek hesle po zdieľaní."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Zdieľanie so skupinami nie je podporované. Namiesto toho budú heslá zdieľané s každým súčasným členom skupiny individuálne."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Skupina používateľov"
     }

--- a/.weblate/sl/messages.json
+++ b/.weblate/sl/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "Šifriranje med koncema bo ob deljenju onemogočeno."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Izmenjava s skupinami ni podprta. Namesto tega se gesla delijo z vsakim trenutnim članom skupine posebej."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Skupina uporabnikov"
     }

--- a/.weblate/sv/messages.json
+++ b/.weblate/sv/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "End-to-End-kryptering kommer att inaktiveras på alla lösenord när de delas."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Att dela med sig av grupper stöds inte. Istället kommer lösenorden delas med varje nuvarande gruppmedlem individuellt."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Användargrupp"
     }

--- a/.weblate/tr/messages.json
+++ b/.weblate/tr/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "End-to-Bitki şifreleme, paylaşılan herhangi bir şifrede devre dışı bırakılacaktır."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Gruplarla paylaşmak desteklenmez. Bunun yerine, şifreler her mevcut grup üyesi ile bireysel olarak paylaşılacaktır."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Kullanıcı grubu"
     }

--- a/.weblate/uk/messages.json
+++ b/.weblate/uk/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "За допомогою шифрування End-to-End буде вимкнено на будь-якому паролі."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "Відсутність з групами не підтримується. Замість паролів буде поділятися з кожним членом групи окремо."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "Група користувачів"
     }

--- a/.weblate/zh_CN/messages.json
+++ b/.weblate/zh_CN/messages.json
@@ -3636,9 +3636,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "共享时, 端到端加密将在任何密码上被禁用 ."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "不支持与群体共享。 相反,密码将单独与每个现任组成员共享."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "用户组"
     }

--- a/.weblate/zh_TW/messages.json
+++ b/.weblate/zh_TW/messages.json
@@ -3541,9 +3541,6 @@
     "frontend-BatchActionShareDialogCseDisableWarning": {
         "message": "在共享口令上被關閉 ."
     },
-    "frontend-BatchActionShareDialogGroupShareWarning": {
-        "message": "不支持同群分享。 取而代之的是, 密碼會被分別地和目前的團體成員分享 ."
-    },
     "frontend-BatchShareSubnameGroup": {
         "message": "使用者群組"
     }

--- a/cypress/e2e/group-share.cy.js
+++ b/cypress/e2e/group-share.cy.js
@@ -1,0 +1,169 @@
+/**
+ * Integration test for sharing a password with a group (issue #582).
+ *
+ * The test drives the real Nextcloud from the docker environment, so it needs
+ * `npm run start` and a build. Group membership is changed with occ, the sharing
+ * cron is triggered through the same app route the frontend uses.
+ *
+ * Nextcloud 34 rejects the bundled Electron, so run it with Chrome:
+ * npx cypress run --spec cypress/e2e/group-share.cy.js --browser chrome
+ */
+
+const OCC       = 'docker exec -u www-data passwords-php ./occ';
+const GROUP     = 'pw-cypress-group';
+const PASSWORD  = 'Cypress Group Share';
+const MEMBER    = 'max';
+const LATE_USER = 'erika';
+
+function occ(command) {
+    return cy.exec(`${OCC} ${command}`, {failOnNonZeroExit: false});
+}
+
+/**
+ * The cron route is limited to 3 calls per 10 seconds per user,
+ * so the calls have to be spaced out to not run into the rate limit
+ */
+function runSharingCron() {
+    cy.wait(4000);
+
+    return cy.request({
+        url    : 'https://localhost/index.php/apps/passwords/cron/sharing',
+        auth   : {user: 'admin', pass: 'admin'},
+        headers: {'OCS-APIRequest': 'true'}
+    }).its('body.success').should('eq', true);
+}
+
+/**
+ * cy.request sends the session cookie of the logged in account along with the
+ * basic auth credentials and Nextcloud then answers as the account of the session.
+ * curl has no cookies, so it really answers as the requested account.
+ */
+function passwordLabels(user) {
+    const pass = user === 'admin' ? 'admin':'PasswordsApp';
+
+    return cy.exec(`curl -sk -u ${user}:${pass} -H 'OCS-APIRequest: true' https://localhost/index.php/apps/passwords/api/1.0/password/list`)
+             .then((result) => JSON.parse(result.stdout).map((password) => password.label));
+}
+
+function api(method, route, body) {
+    return cy.request({
+        method,
+        url    : `https://localhost/index.php/apps/passwords/api/1.0/${route}`,
+        auth   : {user: 'admin', pass: 'admin'},
+        headers: {'OCS-APIRequest': 'true'},
+        body
+    });
+}
+
+/**
+ * The test password is recreated for every run so leftovers can not influence the result
+ */
+function resetTestPassword() {
+    api('GET', 'password/list').then((response) => {
+        for(let password of response.body) {
+            if(password.label === PASSWORD) api('DELETE', 'password/delete', {id: password.id});
+        }
+    });
+
+    api('POST', 'password/create', {label: PASSWORD, password: 'cypress-group-secret', username: 'cypress'})
+        .its('status').should('eq', 201);
+}
+
+function openShareTab() {
+    cy.visit('https://localhost/apps/passwords/#/', {retryOnNetworkFailure: true});
+    cy.contains('.row.password', PASSWORD, {timeout: 30000}).rightclick();
+    cy.contains('[role="menuitem"], li', /^\s*Details\s*$/).click();
+    cy.get('#app-sidebar-vue', {timeout: 15000});
+    cy.contains('#app-sidebar-vue [role="tab"]', /share/i).click();
+    cy.get('.sharing-container', {timeout: 15000});
+}
+
+describe('Share a password with a group', () => {
+
+    before(() => {
+        occ(`group:delete ${GROUP}`);
+        occ(`group:add ${GROUP}`);
+        occ(`group:adduser ${GROUP} admin`);
+        occ(`group:adduser ${GROUP} ${MEMBER}`);
+
+        resetTestPassword();
+
+        // remove the shares of a previous run from the accounts of the members.
+        // the first run removes the shares, the second the passwords created from them
+        runSharingCron();
+        runSharingCron();
+        runSharingCron();
+    });
+
+    after(() => {
+        occ(`group:delete ${GROUP}`);
+        api('GET', 'password/list').then((response) => {
+            for(let password of response.body) {
+                if(password.label === PASSWORD) api('DELETE', 'password/delete', {id: password.id});
+            }
+        });
+        runSharingCron();
+        runSharingCron();
+    });
+
+    it('Offers the group as a recipient in the share tab', () => {
+        cy.login();
+        openShareTab();
+
+        cy.get('.sharing-container input.vs__search').type(GROUP);
+        cy.contains('li[role="option"]', GROUP, {timeout: 15000});
+        // groups are marked as such so they can not be confused with a user
+        cy.contains('li[role="option"]', 'User group');
+    });
+
+    it('Creates a single share for the group, not one per member', () => {
+        cy.login();
+        openShareTab();
+
+        cy.get('.sharing-container input.vs__search').type(GROUP);
+        cy.contains('li[role="option"]', GROUP, {timeout: 15000}).click();
+
+        cy.get('.sharing-container .shares .share', {timeout: 30000}).should('have.length', 1);
+        cy.get('.sharing-container .shares .share').should('contain', GROUP);
+        cy.get('.sharing-container .shares .share .group-avatar').should('exist');
+    });
+
+    it('Shares the password with the members of the group', () => {
+        runSharingCron();
+        passwordLabels(MEMBER).should('include', PASSWORD);
+    });
+
+    it('Shares the password with a user who joins the group later', () => {
+        passwordLabels(LATE_USER).should('not.include', PASSWORD);
+
+        occ(`group:adduser ${GROUP} ${LATE_USER}`);
+        runSharingCron();
+
+        passwordLabels(LATE_USER).should('include', PASSWORD);
+    });
+
+    it('Revokes the password from a user who leaves the group', () => {
+        occ(`group:removeuser ${GROUP} ${MEMBER}`);
+
+        // one run is enough, the group sync runs before the orphaned passwords are deleted.
+        // the second run makes sure that nothing is recreated afterwards
+        runSharingCron();
+        runSharingCron();
+
+        passwordLabels(MEMBER).should('not.include', PASSWORD);
+        passwordLabels(LATE_USER).should('include', PASSWORD);
+    });
+
+    it('Revokes the password from everyone when the group share is deleted', () => {
+        cy.login();
+        openShareTab();
+
+        cy.get('.sharing-container .shares .share', {timeout: 30000}).should('have.length', 1);
+        cy.get('.sharing-container .shares .share .options span').last().click();
+
+        runSharingCron();
+        runSharingCron();
+
+        passwordLabels(LATE_USER).should('not.include', PASSWORD);
+    });
+});

--- a/src/js/Actions/BatchActions/ShareBatchAction.js
+++ b/src/js/Actions/BatchActions/ShareBatchAction.js
@@ -19,6 +19,7 @@ import DeleteShareAction from "@js/Actions/Share/DeleteShareAction";
 import API from "@js/Helper/api";
 import ToastService from "@js/Services/ToastService";
 import CreateGroupShareAction from "@js/Actions/Share/CreateGroupShareAction";
+import LocalisationService from "@js/Services/LocalisationService";
 
 export default class ShareBatchAction extends BatchAction {
 
@@ -47,7 +48,10 @@ export default class ShareBatchAction extends BatchAction {
                 MessageService.alert((await messages).join(' '));
             }
         } else if(sharingOptions.action === 'delete') {
-            await this.#deleteShares(sharingOptions);
+            let messages = await this.#deleteShares(sharingOptions);
+            if(messages.length > 0) {
+                MessageService.alert(messages.join(' '));
+            }
         }
 
         await this.#runSharingCron();
@@ -149,17 +153,35 @@ export default class ShareBatchAction extends BatchAction {
             messages = [];
         for(let recipient of sharingOptions.recipients) {
             for(let password of this._items.passwords) {
-                let action = new DeleteShareAction(
-                    password,
-                    recipient
+                promises.push(
+                    this.#deleteShare(password, recipient, messages)
                 );
-                promises.push(action.run());
             }
         }
 
         await Promise.all(promises);
 
         return messages;
+    }
+
+    async #deleteShare(password, recipient, messages) {
+        try {
+            let action = new DeleteShareAction(password, recipient);
+            await action.run();
+
+            if(action.blockedByGroupShare) {
+                // The messages are joined into one text, so they have to be translated here
+                messages.push(
+                    LocalisationService.translateArray(
+                        ['DeleteShareErrorGroupShare', {password: password.label, recipient: recipient.displayName}]
+                    )
+                );
+            }
+        } catch(e) {
+            LoggingService.error(e);
+            let message = e.hasOwnProperty('message') ? e.message:e.statusText;
+            messages.push(LocalisationService.translateArray(['Unable to share password: {message}', {message}]));
+        }
     }
 
     async #runSharingCron() {

--- a/src/js/Actions/Share/CreateGroupShareAction.js
+++ b/src/js/Actions/Share/CreateGroupShareAction.js
@@ -8,50 +8,34 @@
  * created by Marius David Wieschollek.
  */
 
-import {getCurrentUser} from "@nextcloud/auth";
-import API from "@js/Helper/api";
 import CreateShareAction from "@js/Actions/Share/CreateShareAction";
 import CreateShareError from "@js/Actions/Share/CreateShareError";
 import LoggingService from "@js/Services/LoggingService";
+import LocalisationService from "@js/Services/LocalisationService";
 
+/**
+ * Creates a single share for a group.
+ * The server expands it into one share per group member and keeps
+ * that list in sync with the members of the group.
+ */
 export default class CreateGroupShareAction {
     #password;
     #options;
     #group;
-    #user;
 
     constructor(password, group, options) {
         this.#password = password;
         this.#group = group;
         this.#options = options;
-        this.#user = getCurrentUser();
     }
 
     async run() {
-        let messages = [],
-            promises = [];
-        const users = await API.resolveGroup(this.#group.id);
+        let messages = [];
 
-        for(let userId in users) {
-            if(users.hasOwnProperty(userId) && userId !== this.#user.uid) {
-                const recipient = {id: userId, displayName: users[userId]};
-
-                promises.push(
-                    this.#createShare(recipient, messages)
-                );
-            }
-        }
-
-        await Promise.all(promises);
-
-        return messages;
-    }
-
-    async #createShare(receiver, messages) {
         try {
             let action = new CreateShareAction(
                 this.#password,
-                receiver,
+                {id: this.#group.id, displayName: this.#group.displayName, type: 'group'},
                 this.#options
             );
 
@@ -60,8 +44,14 @@ export default class CreateGroupShareAction {
             if(e instanceof CreateShareError) {
                 messages.push(e.message);
             } else {
+                // The error is reported as well, otherwise the user is told that everything worked.
+                // CreateShareError translates its message, so these have to be translated too
                 LoggingService.error(e);
+                let message = e.hasOwnProperty('message') ? e.message:e.statusText;
+                messages.push(LocalisationService.translateArray(['Unable to share password: {message}', {message}]));
             }
         }
+
+        return messages;
     }
 }

--- a/src/js/Actions/Share/CreateShareAction.js
+++ b/src/js/Actions/Share/CreateShareAction.js
@@ -21,12 +21,23 @@ export default class CreateShareAction {
     #options;
     #recipient;
     #user;
+    #cseDisabled = false;
 
     constructor(password, recipient, options) {
         this.#password = password;
         this.#recipient = recipient;
         this.#options = options;
         this.#user = getCurrentUser();
+    }
+
+    /**
+     * Whether the end-to-end encryption of the password was disabled.
+     * This can not be undone, even if the share was not created afterwards.
+     *
+     * @returns {Boolean}
+     */
+    get cseDisabled() {
+        return this.#cseDisabled;
     }
 
     async run() {
@@ -59,7 +70,7 @@ export default class CreateShareAction {
     }
 
     #isShareWithOwner() {
-        return this.#password.hasOwnProperty('share') && this.#password.share !== null && !this.#password.share.owner.id === this.#recipient.id;
+        return this.#password.hasOwnProperty('share') && this.#password.share !== null && this.#password.share.owner.id === this.#recipient.id;
     }
 
     async #loadShares() {
@@ -74,13 +85,16 @@ export default class CreateShareAction {
         for(let index in this.#password.shares) {
             let share = this.#password.shares[index];
 
+            // The shares of the members of a group share are managed by the server
+            if(share.parentShare) continue;
+
             if(share.receiver.id === this.#recipient.id) {
                 if(!this.#options.overwrite) {
                     return false;
                 }
 
                 await API.deleteShare(share.id);
-                delete this.#password[share.id];
+                delete this.#password.shares[share.id];
             }
         }
 
@@ -94,16 +108,19 @@ export default class CreateShareAction {
         password.shared = true;
 
         this.#password = await PasswordManager.updatePassword(password);
+        this.#cseDisabled = true;
     }
 
     async #createShare() {
-        let share = {
-            password : this.#password.id,
-            expires  : this.#getExpiryDate(),
-            editable : this.#getEditable(),
-            shareable: this.#options.shareable,
-            receiver : this.#recipient.id
-        };
+        let type  = this.#recipient.type === 'group' ? 'group':'user',
+            share = {
+                password : this.#password.id,
+                expires  : this.#getExpiryDate(),
+                editable : this.#getEditable(),
+                shareable: this.#options.shareable,
+                receiver : this.#recipient.id,
+                type
+            };
 
         let shareModel = await API.createShare(share);
         share.id = shareModel.id;
@@ -112,7 +129,7 @@ export default class CreateShareAction {
             id  : this.#user.uid,
             name: this.#user.displayName
         };
-        share.receiver = {id: this.#recipient.id, name: this.#recipient.displayName};
+        share.receiver = {id: this.#recipient.id, name: this.#recipient.displayName, type};
 
         this.#password.shares[share.id] = await API._processShare(share);
     }

--- a/src/js/Actions/Share/DeleteShareAction.js
+++ b/src/js/Actions/Share/DeleteShareAction.js
@@ -14,11 +14,21 @@ import {emitMultiple} from "@js/Helper/event-bus";
 export default class DeleteShareAction {
     #password;
     #recipient;
+    #blockedByGroupShare = false;
 
     constructor(password, recipient) {
         this.#password = password;
         this.#recipient = recipient;
 
+    }
+
+    /**
+     * Whether the recipient keeps the password because a group share gives it to them
+     *
+     * @returns {Boolean}
+     */
+    get blockedByGroupShare() {
+        return this.#blockedByGroupShare;
     }
 
     async run() {
@@ -38,10 +48,17 @@ export default class DeleteShareAction {
         for(let index in this.#password.shares) {
             let share = this.#password.shares[index];
 
-            if(share.receiver.id === this.#recipient.id) {
-                await API.deleteShare(share.id);
-                delete this.#password.shares[index];
+            if(share.receiver.id !== this.#recipient.id) continue;
+
+            // The shares of the members of a group share belong to the group share and
+            // can not be deleted on their own, the server rejects it
+            if(share.parentShare) {
+                this.#blockedByGroupShare = true;
+                continue;
             }
+
+            await API.deleteShare(share.id);
+            delete this.#password.shares[index];
         }
 
         emitMultiple(['passwords:password:updated', 'passwords:item:updated'], this.#password);

--- a/src/lib/Controller/Api/ShareApiController.php
+++ b/src/lib/Controller/Api/ShareApiController.php
@@ -41,7 +41,7 @@ class ShareApiController extends AbstractApiController {
     /**
      * @var array
      */
-    protected array $allowedFilterFields = ['created', 'updated', 'userId', 'receiver', 'expires', 'editable', 'shareable'];
+    protected array $allowedFilterFields = ['created', 'updated', 'userId', 'receiver', 'expires', 'editable', 'shareable', 'type'];
 
     /**
      * ShareApiController constructor.
@@ -177,8 +177,12 @@ class ShareApiController extends AbstractApiController {
             }
         }
 
-        $recipient = $this->shareUserList->mapRecipientToUid($recipient);
-        if(!$this->shareUserList->canShareWithUser($recipient)) throw new ApiException('Invalid recipient uid', Http::STATUS_BAD_REQUEST);
+        if($type === Share::TYPE_GROUP) {
+            if(!$this->shareUserList->canShareWithGroup($recipient)) throw new ApiException('Invalid recipient group', Http::STATUS_BAD_REQUEST);
+        } else {
+            $recipient = $this->shareUserList->mapRecipientToUid($recipient);
+            if(!$this->shareUserList->canShareWithUser($recipient)) throw new ApiException('Invalid recipient uid', Http::STATUS_BAD_REQUEST);
+        }
 
         $share = $this->createPasswordShare->createPasswordShare(
             $password,
@@ -218,6 +222,7 @@ class ShareApiController extends AbstractApiController {
         if($share->getUserId() !== $this->userId) {
             throw new ApiException('Access denied', Http::STATUS_FORBIDDEN);
         }
+        $this->checkIsNotDerived($share);
 
         $share = $this->updatePasswordShareHelper->updatePasswordShare($share, $expires, $editable, $shareable);
 
@@ -241,10 +246,26 @@ class ShareApiController extends AbstractApiController {
         if($model->getUserId() !== $this->userId) {
             throw new ApiException('Access denied', Http::STATUS_FORBIDDEN);
         }
+        $this->checkIsNotDerived($model);
 
         $this->modelService->delete($model);
 
         return $this->createJsonResponse(['id' => $model->getUuid()]);
+    }
+
+    /**
+     * The shares of the members of a group share belong to the group share.
+     * Changing or deleting them directly would be undone by the next cron run,
+     * so it is rejected instead of silently ignored.
+     *
+     * @param Share $share
+     *
+     * @throws ApiException
+     */
+    protected function checkIsNotDerived(Share $share): void {
+        if($share->isDerived()) {
+            throw new ApiException('Share belongs to a group share', Http::STATUS_BAD_REQUEST);
+        }
     }
 
     /**

--- a/src/lib/Cron/SynchronizeShares.php
+++ b/src/lib/Cron/SynchronizeShares.php
@@ -15,6 +15,7 @@ use Exception;
 use OCA\Passwords\Db\Password;
 use OCA\Passwords\Db\PasswordRevision;
 use OCA\Passwords\Db\Share;
+use OCA\Passwords\Helper\Sharing\GroupShareSyncHelper;
 use OCA\Passwords\Services\ConfigurationService;
 use OCA\Passwords\Services\EnvironmentService;
 use OCA\Passwords\Services\LoggingService;
@@ -54,6 +55,7 @@ class SynchronizeShares extends AbstractTimedJob {
      * @param PasswordService         $passwordService
      * @param NotificationService     $notificationService
      * @param PasswordRevisionService $passwordRevisionService
+     * @param GroupShareSyncHelper    $groupShareSync
      */
     public function __construct(
         ITimeFactory                      $time,
@@ -64,7 +66,8 @@ class SynchronizeShares extends AbstractTimedJob {
         EnvironmentService                $environment,
         protected PasswordService         $passwordService,
         protected NotificationService     $notificationService,
-        protected PasswordRevisionService $passwordRevisionService
+        protected PasswordRevisionService $passwordRevisionService,
+        protected GroupShareSyncHelper    $groupShareSync
     ) {
         parent::__construct($time, $logger, $config, $environment);
     }
@@ -78,8 +81,12 @@ class SynchronizeShares extends AbstractTimedJob {
         if(!$this->canExecute()) return;
         $this->config->setAppValue(self::EXECUTION_TIMESTAMP, time());
 
-        $this->deleteOrphanedTargetPasswords();
+        // Expired group shares are removed before they are expanded again,
+        // and the group sync runs before the orphaned passwords are deleted so
+        // that a user who left a group loses the password in the same run
         $this->deleteExpiredShares();
+        $this->synchronizeGroupShares();
+        $this->deleteOrphanedTargetPasswords();
         $this->createNewShares();
         $this->removeSharedAttribute();
         $this->updatePasswords();
@@ -133,21 +140,48 @@ class SynchronizeShares extends AbstractTimedJob {
     protected function deleteExpiredShares(): void {
         $total = 0;
         do {
-            $shares = $this->shareService->findExpired();
+            // The expiry date of a share created for a group member is a copy of the one of the group
+            // share, so it is deleted together with the group share and never on its own. An outdated
+            // copy would otherwise delete the password of a member whose access was just extended.
+            // These shares must be removed before the shares are counted, they are never deleted here
+            // and would make this loop run forever.
+            $shares = array_values(
+                array_filter(
+                    $this->shareService->findExpired(),
+                    function (Share $share) { return !$share->isDerived(); }
+                )
+            );
             $count  = count($shares);
             $total  += $count;
 
             foreach($shares as $share) {
-                try {
-                    $password = $this->passwordService->findByUuid($share->getTargetPassword());
-                    $this->passwordService->delete($password);
-                } catch(DoesNotExistException $e) {
+                // Group shares have no target password, they only exist to create the shares of the group members
+                if($share->getTargetPassword() !== null) {
+                    try {
+                        $password = $this->passwordService->findByUuid($share->getTargetPassword());
+                        $this->passwordService->delete($password);
+                    } catch(DoesNotExistException $e) {
+                    }
                 }
                 $this->shareService->delete($share);
             }
         } while($count !== 0);
 
         $this->logger->debugOrInfo(['Deleted %s expired share(s)', $total], $total);
+    }
+
+    /**
+     * Creates and removes the shares for the members of a group share
+     *
+     * @throws Exception
+     */
+    protected function synchronizeGroupShares(): void {
+        $result = $this->groupShareSync->synchronize();
+
+        $this->logger->debugOrInfo(
+            ['Created %s, updated %s and deleted %s group member share(s)', $result['created'], $result['updated'], $result['deleted']],
+            $result['created'] + $result['updated'] + $result['deleted']
+        );
     }
 
     /**

--- a/src/lib/Db/Share.php
+++ b/src/lib/Db/Share.php
@@ -18,6 +18,8 @@ namespace OCA\Passwords\Db;
  * @method void setTargetPassword(string $targetPassword)
  * @method string getReceiver()
  * @method void setReceiver(string $receiver)
+ * @method string|null getParentShare()
+ * @method void setParentShare(string|null $parentShare)
  * @method bool getEditable()
  * @method void setEditable(bool $editable)
  * @method bool getShareable()
@@ -88,12 +90,20 @@ class Share extends AbstractEntity implements EntityInterface {
     protected bool $targetUpdated;
 
     /**
+     * Uuid of the group share which created this share
+     *
+     * @var string|null
+     */
+    protected ?string $parentShare;
+
+    /**
      * Password constructor.
      */
     public function __construct() {
         $this->addType('type', 'string');
         $this->addType('client', 'string');
         $this->addType('receiver', 'string');
+        $this->addType('parentShare', 'string');
         $this->addType('sourcePassword', 'string');
         $this->addType('targetPassword', 'string');
 
@@ -105,6 +115,22 @@ class Share extends AbstractEntity implements EntityInterface {
         $this->addType('targetUpdated', 'boolean');
 
         parent::__construct();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGroupShare(): bool {
+        return $this->getType() === self::TYPE_GROUP;
+    }
+
+    /**
+     * Whether this share was created by the cron job from a group share
+     *
+     * @return bool
+     */
+    public function isDerived(): bool {
+        return $this->getParentShare() !== null;
     }
 
     /**

--- a/src/lib/EventListener/Share/ShareDeletedListener.php
+++ b/src/lib/EventListener/Share/ShareDeletedListener.php
@@ -13,7 +13,9 @@ namespace OCA\Passwords\EventListener\Share;
 
 use Exception;
 use OCA\Passwords\Db\Password;
+use OCA\Passwords\Db\Share;
 use OCA\Passwords\Events\Share\ShareDeletedEvent;
+use OCA\Passwords\Helper\Sharing\GroupShareSyncHelper;
 use OCA\Passwords\Services\Object\PasswordService;
 use OCA\Passwords\Services\Object\ShareService;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -41,10 +43,15 @@ class ShareDeletedListener implements IEventListener {
     /**
      * ShareHook constructor.
      *
-     * @param ShareService    $shareService
-     * @param PasswordService $passwordService
+     * @param ShareService         $shareService
+     * @param PasswordService      $passwordService
+     * @param GroupShareSyncHelper $groupShareSync
      */
-    public function __construct(ShareService $shareService, PasswordService $passwordService) {
+    public function __construct(
+        ShareService                     $shareService,
+        PasswordService                  $passwordService,
+        protected GroupShareSyncHelper   $groupShareSync
+    ) {
         $this->passwordService = $passwordService;
         $this->shareService    = $shareService;
     }
@@ -58,7 +65,9 @@ class ShareDeletedListener implements IEventListener {
     public function handle(Event $event): void {
         if(!($event instanceof ShareDeletedEvent)) return;
         try {
-            $share  = $event->getShare();
+            $share = $event->getShare();
+            if($share->isGroupShare()) $this->deleteGroupMemberShares($share);
+
             $shares = $this->shareService->findBySourcePassword($share->getSourcePassword());
 
             if(empty($shares)) {
@@ -69,5 +78,17 @@ class ShareDeletedListener implements IEventListener {
             }
         } catch(DoesNotExistException $e) {
         }
+    }
+
+    /**
+     * Deleting a group share also revokes the access of all group members.
+     * Members who are covered by another group share of the same password keep it.
+     *
+     * @param Share $groupShare
+     *
+     * @throws Exception
+     */
+    protected function deleteGroupMemberShares(Share $groupShare): void {
+        $this->groupShareSync->removeGroupShare($groupShare);
     }
 }

--- a/src/lib/Helper/ApiObjects/ShareObjectHelper.php
+++ b/src/lib/Helper/ApiObjects/ShareObjectHelper.php
@@ -20,6 +20,7 @@ use OCA\Passwords\Services\UserService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -50,13 +51,15 @@ class ShareObjectHelper extends AbstractObjectHelper {
      * @param ContainerInterface $container
      * @param EnvironmentService $environment
      * @param PasswordService    $passwordService
+     * @param IGroupManager      $groupManager
      */
     public function __construct(
         protected IConfig            $config,
         protected UserService        $userService,
         protected ContainerInterface $container,
         EnvironmentService           $environment,
-        protected PasswordService    $passwordService
+        protected PasswordService    $passwordService,
+        protected IGroupManager      $groupManager
     ) {
         $this->userId = $environment->getUserId();
     }
@@ -111,6 +114,8 @@ class ShareObjectHelper extends AbstractObjectHelper {
             'editable'      => $share->isEditable(),
             'shareable'     => $shareable,
             'password'      => $password,
+            'type'          => $share->getType(),
+            'parentShare'   => $share->getParentShare(),
             'updatePending' => $share->isSourceUpdated() || $share->isTargetUpdated(),
             'owner'         => [
                 'id'   => $share->getUserId(),
@@ -118,10 +123,28 @@ class ShareObjectHelper extends AbstractObjectHelper {
             ],
             'receiver'      => [
                 'id'   => $share->getReceiver(),
-                'name' => $this->userService->getUserName($share->getReceiver())
+                'name' => $this->getReceiverName($share),
+                'type' => $share->getType()
             ],
             'client'        => $share->getClient(),
         ];
+    }
+
+    /**
+     * The receiver of a group share is a group id, so it can not be resolved with the user service
+     *
+     * @param Share $share
+     *
+     * @return string
+     */
+    protected function getReceiverName(Share $share): string {
+        if($share->isGroupShare()) {
+            $group = $this->groupManager->get($share->getReceiver());
+
+            return $group === null ? $share->getReceiver():$group->getDisplayName();
+        }
+
+        return $this->userService->getUserName($share->getReceiver());
     }
 
     /**

--- a/src/lib/Helper/Settings/ShareSettingsHelper.php
+++ b/src/lib/Helper/Settings/ShareSettingsHelper.php
@@ -61,7 +61,7 @@ class ShareSettingsHelper {
             case 'autocomplete':
                 return $this->isSharingEnumerationEnabled();
             case 'types':
-                return ['user'];
+                return $this->isGroupSharingEnabled() ? ['user', 'group']:['user'];
         }
 
         return null;

--- a/src/lib/Helper/Sharing/CreatePasswordShareHelper.php
+++ b/src/lib/Helper/Sharing/CreatePasswordShareHelper.php
@@ -135,7 +135,10 @@ class CreatePasswordShareHelper {
      * @throws ApiException
      */
     protected function checkType(string $type): void {
-        if($type !== 'user') throw new ApiException('Invalid share type', Http::STATUS_BAD_REQUEST);
+        if($type === Share::TYPE_USER) return;
+        if($type === Share::TYPE_GROUP && $this->shareSettings->get('groups.enabled')) return;
+
+        throw new ApiException('Invalid share type', Http::STATUS_BAD_REQUEST);
     }
 
     /**

--- a/src/lib/Helper/Sharing/GroupShareSyncHelper.php
+++ b/src/lib/Helper/Sharing/GroupShareSyncHelper.php
@@ -1,0 +1,477 @@
+<?php
+/*
+ * @copyright 2026 Passwords App
+ *
+ * @author Marius David Wieschollek
+ * @license AGPL-3.0
+ *
+ * This file is part of the Passwords App
+ * created by Marius David Wieschollek.
+ */
+
+namespace OCA\Passwords\Helper\Sharing;
+
+use Exception;
+use OCA\Passwords\Db\Share;
+use OCA\Passwords\Services\LoggingService;
+use OCA\Passwords\Services\Object\ShareService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IGroupManager;
+use Throwable;
+
+/**
+ * Expands group shares into one share per group member and keeps them in sync
+ * with the current members of the group.
+ *
+ * This runs from the cron job without a session user, so no permission checks
+ * happen here. Whether the owner may share with the group at all is decided
+ * once, when the group share is created, in RecipientSearchHelper::canShareWithGroup().
+ *
+ * @package OCA\Passwords\Helper\Sharing
+ */
+class GroupShareSyncHelper {
+
+    /**
+     * GroupShareSyncHelper constructor.
+     *
+     * @param ShareService   $shareService
+     * @param IGroupManager  $groupManager
+     * @param LoggingService $logger
+     */
+    public function __construct(
+        protected ShareService   $shareService,
+        protected IGroupManager  $groupManager,
+        protected LoggingService $logger
+    ) {
+    }
+
+    /**
+     * @return array ['created' => int, 'deleted' => int, 'updated' => int]
+     * @throws Exception
+     */
+    public function synchronize(): array {
+        $result      = ['created' => 0, 'deleted' => 0, 'updated' => 0];
+        $groupShares = $this->shareService->findAllGroupShares();
+
+        // The members of every group are resolved up front. A group which can not be
+        // resolved right now has unknown members, removing the shares of all of them
+        // would destroy their passwords, so those group shares are left alone.
+        $members = [];
+        foreach($groupShares as $groupShare) {
+            $members[ $groupShare->getUuid() ] = $this->runSafely(
+                $groupShare, fn() => $this->getGroupMembers($groupShare)
+            );
+        }
+
+        // The shares of former members are removed for every group share before any new
+        // share is created. Otherwise a member who moved from one group to another could
+        // lose their password, because the share of the group they left still looks like
+        // an existing share while the group they joined is processed.
+        foreach($groupShares as $groupShare) {
+            if($members[ $groupShare->getUuid() ] === null) continue;
+
+            $this->runSafely(
+                $groupShare, function () use ($groupShare, $groupShares, $members, &$result) {
+                $this->removeFormerMembers($groupShare, $groupShares, $members, $result);
+            }
+            );
+        }
+
+        foreach($groupShares as $groupShare) {
+            if($members[ $groupShare->getUuid() ] === null) continue;
+
+            $this->runSafely(
+                $groupShare, function () use ($groupShare, $members, &$result) {
+                $this->addNewMembers($groupShare, $members[ $groupShare->getUuid() ], $result);
+            }
+            );
+        }
+
+        $this->removeOrphanedShares($groupShares, $members, $result);
+
+        return $result;
+    }
+
+    /**
+     * Removes the shares of members whose group share no longer exists.
+     * Only existing group shares are synchronized, so such a share would never be
+     * looked at again and the member would keep the password forever.
+     *
+     * @param Share[] $groupShares
+     * @param array   $members
+     * @param array   $result
+     *
+     * @throws Exception
+     */
+    protected function removeOrphanedShares(array $groupShares, array $members, array &$result): void {
+        $knownGroupShares = [];
+        foreach($groupShares as $groupShare) {
+            $knownGroupShares[ $groupShare->getUuid() ] = true;
+        }
+
+        foreach($this->shareService->findAllDerivedShares() as $child) {
+            if(isset($knownGroupShares[ $child->getParentShare() ])) continue;
+
+            try {
+                $newParent = $this->findCoveringGroupShare($child, $groupShares, $members, $child->getReceiver());
+
+                if($newParent === null) {
+                    $this->shareService->delete($child);
+                    $result['deleted']++;
+                    continue;
+                }
+
+                $this->reparentChildShare($newParent, $child);
+                $result['updated']++;
+            } catch(Throwable $e) {
+                $this->logger->logException(
+                    $e,
+                    [],
+                    "Could not clean up the orphaned share {$child->getUuid()}: {$e->getMessage()}"
+                );
+            }
+        }
+    }
+
+    /**
+     * Revokes the shares which were created for the members of a deleted group share.
+     * A member who is also in another group with a share of the same password keeps
+     * their share, it is handed over to that group share.
+     *
+     * @param Share $groupShare
+     *
+     * @throws Exception
+     */
+    public function removeGroupShare(Share $groupShare): void {
+        $children = $this->shareService->findByParentShare($groupShare->getUuid());
+        if(empty($children)) return;
+
+        $groupShares = [];
+        $members     = [];
+        foreach($this->shareService->findAllGroupShares() as $candidate) {
+            if($candidate->getUuid() === $groupShare->getUuid()) continue;
+            if($candidate->getSourcePassword() !== $groupShare->getSourcePassword()) continue;
+
+            $groupShares[]                    = $candidate;
+            $members[ $candidate->getUuid() ] = $this->runSafely(
+                $candidate, fn() => $this->getGroupMembers($candidate)
+            );
+        }
+
+        // A group which can not be resolved right now may or may not contain the members.
+        // Deleting their shares would destroy their passwords, so the decision is left to
+        // a later run of the cron job by handing the shares over to that group share.
+        $unresolved = $this->findUnresolvedGroupShare($groupShares, $members);
+
+        foreach($children as $child) {
+            $newParent = $this->findCoveringGroupShare($groupShare, $groupShares, $members, $child->getReceiver());
+
+            if($newParent === null) {
+                if($unresolved === null) {
+                    $this->shareService->delete($child);
+                    continue;
+                }
+
+                $this->logger->warning(
+                    "Kept the share {$child->getUuid()} of the deleted group share {$groupShare->getUuid()}, ".
+                    "the group of {$unresolved->getUuid()} can not be resolved right now"
+                );
+                $newParent = $unresolved;
+            }
+
+            $this->reparentChildShare($newParent, $child);
+        }
+    }
+
+    /**
+     * @param Share[] $groupShares
+     * @param array   $members
+     *
+     * @return Share|null
+     */
+    protected function findUnresolvedGroupShare(array $groupShares, array $members): ?Share {
+        foreach($groupShares as $candidate) {
+            if($members[ $candidate->getUuid() ] === null) return $candidate;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Share    $groupShare
+     * @param callable $callback
+     *
+     * @return mixed Null if the callback failed
+     */
+    protected function runSafely(Share $groupShare, callable $callback): mixed {
+        try {
+            return $callback();
+        } catch(Throwable $e) {
+            $this->logger->logException(
+                $e,
+                [],
+                "Could not synchronize group share {$groupShare->getUuid()}: {$e->getMessage()}"
+            );
+
+            return null;
+        }
+    }
+
+    /**
+     * Removes the shares of users who are no longer in the group.
+     * If another group share of the same password still covers the user, the share is
+     * moved to that group share instead, so the user keeps the password they already have.
+     *
+     * @param Share   $groupShare
+     * @param Share[] $groupShares
+     * @param array   $members
+     * @param array   $result
+     *
+     * @throws Exception
+     */
+    protected function removeFormerMembers(Share $groupShare, array $groupShares, array $members, array &$result): void {
+        foreach($this->shareService->findByParentShare($groupShare->getUuid()) as $child) {
+            if(in_array($child->getReceiver(), $members[ $groupShare->getUuid() ], true)) {
+                if($this->updateChildShare($groupShare, $child)) $result['updated']++;
+                continue;
+            }
+
+            $newParent = $this->findCoveringGroupShare($groupShare, $groupShares, $members, $child->getReceiver());
+            if($newParent !== null) {
+                $this->reparentChildShare($newParent, $child);
+                $result['updated']++;
+                continue;
+            }
+
+            $this->shareService->delete($child);
+            $result['deleted']++;
+        }
+    }
+
+    /**
+     * @param Share  $groupShare
+     * @param array  $groupMembers
+     * @param array  $result
+     *
+     * @throws Exception
+     */
+    protected function addNewMembers(Share $groupShare, array $groupMembers, array &$result): void {
+        $existingShares = $this->shareService->findBySourcePassword($groupShare->getSourcePassword());
+
+        foreach($groupMembers as $member) {
+            if($this->hasShare($existingShares, $groupShare, $member)) continue;
+
+            $existingShares[] = $this->createChildShare($groupShare, $member);
+            $result['created']++;
+        }
+
+        if($groupShare->isSourceUpdated()) {
+            $groupShare->setSourceUpdated(false);
+            $this->shareService->save($groupShare);
+        }
+    }
+
+    /**
+     * Another group share of the same password which still contains the user.
+     * The share to compare with is either the group share which no longer contains
+     * the user, or the share of the member itself. Both have the same password and owner.
+     *
+     * @param Share   $share
+     * @param Share[] $groupShares
+     * @param array   $members
+     * @param string  $userId
+     *
+     * @return Share|null
+     */
+    protected function findCoveringGroupShare(Share $share, array $groupShares, array $members, string $userId): ?Share {
+        foreach($groupShares as $candidate) {
+            if($candidate->getUuid() === $share->getUuid()) continue;
+            if($candidate->getSourcePassword() !== $share->getSourcePassword()) continue;
+            if($candidate->getUserId() !== $share->getUserId()) continue;
+            if($members[ $candidate->getUuid() ] === null) continue;
+            if(!in_array($userId, $members[ $candidate->getUuid() ], true)) continue;
+
+            return $candidate;
+        }
+
+        return null;
+    }
+
+    /**
+     * The members which should receive the password.
+     * The owner of the share is skipped, sharing with yourself is not possible.
+     * Everyone further up in the share lineage is skipped as well,
+     * sharing the password back to them would create a share loop.
+     *
+     * @param Share $groupShare
+     *
+     * @return string[]|null Null if the group can not be resolved
+     */
+    protected function getGroupMembers(Share $groupShare): ?array {
+        $group = $this->groupManager->get($groupShare->getReceiver());
+        if($group === null) {
+            $this->logger->warning(
+                "Group {$groupShare->getReceiver()} of share {$groupShare->getUuid()} does not exist"
+            );
+
+            return null;
+        }
+
+        $excluded = $this->getLineageUserIds($groupShare);
+
+        $members = [];
+        foreach($group->getUsers() as $user) {
+            if(in_array($user->getUID(), $excluded, true)) continue;
+            $members[] = $user->getUID();
+        }
+
+        return $members;
+    }
+
+    /**
+     * The owner of the group share and every user the password was shared through
+     * before it reached the owner of the group share.
+     * Creating a share for one of them would be deleted again by the share loop
+     * detection of the cron job and recreated on every run.
+     *
+     * @param Share $groupShare
+     *
+     * @return string[]
+     */
+    protected function getLineageUserIds(Share $groupShare): array {
+        $userIds = [$groupShare->getUserId()];
+
+        $passwordUuid = $groupShare->getSourcePassword();
+        $seen         = [];
+        while(!empty($passwordUuid) && !isset($seen[ $passwordUuid ])) {
+            $seen[ $passwordUuid ] = true;
+
+            try {
+                $parentShare = $this->shareService->findByTargetPassword($passwordUuid);
+            } catch(DoesNotExistException $e) {
+                // The password was not shared with the owner, the chain ends here
+                break;
+            } catch(Throwable $e) {
+                $this->logger->logException(
+                    $e,
+                    [],
+                    "Could not read the share lineage of {$groupShare->getUuid()}: {$e->getMessage()}"
+                );
+                break;
+            }
+
+            $userIds[]    = $parentShare->getUserId();
+            $passwordUuid = $parentShare->getSourcePassword();
+        }
+
+        // A user id of "0" is falsy, so the filter can not be used without a callback
+        return array_values(array_unique(array_filter($userIds, fn($userId) => $userId !== null && $userId !== '')));
+    }
+
+    /**
+     * Whether the member already has the password, either through a direct share,
+     * through this group share or through another group share
+     *
+     * @param Share[] $existingShares
+     * @param Share   $groupShare
+     * @param string  $userId
+     *
+     * @return bool
+     */
+    protected function hasShare(array $existingShares, Share $groupShare, string $userId): bool {
+        foreach($existingShares as $share) {
+            if($share->getReceiver() === $userId && $share->getUserId() === $groupShare->getUserId()) return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Share  $groupShare
+     * @param string $userId
+     *
+     * @return Share
+     * @throws Exception
+     */
+    protected function createChildShare(Share $groupShare, string $userId): Share {
+        // The cron job has no session user, so the owner has to be passed explicitly
+        $share = $this->shareService->create(
+            $groupShare->getSourcePassword(),
+            $userId,
+            Share::TYPE_USER,
+            $groupShare->isEditable(),
+            $groupShare->getExpires(),
+            $groupShare->isShareable(),
+            $groupShare->getUuid(),
+            $groupShare->getUserId()
+        );
+
+        $share->setClient($groupShare->getClient());
+        $this->shareService->save($share);
+
+        return $share;
+    }
+
+    /**
+     * Hand the share of a member over to another group share which still contains them,
+     * so that the password of the member survives the group change
+     *
+     * @param Share $groupShare
+     * @param Share $child
+     *
+     * @throws Exception
+     */
+    protected function reparentChildShare(Share $groupShare, Share $child): void {
+        $child->setParentShare($groupShare->getUuid());
+        if($this->copyPermissions($groupShare, $child)) $child->setSourceUpdated(true);
+
+        $this->shareService->save($child);
+    }
+
+    /**
+     * Copy permission changes of the group share to the share of a group member
+     *
+     * @param Share $groupShare
+     * @param Share $child
+     *
+     * @return bool
+     * @throws Exception
+     */
+    protected function updateChildShare(Share $groupShare, Share $child): bool {
+        if(!$this->copyPermissions($groupShare, $child)) return false;
+
+        $child->setSourceUpdated(true);
+        $this->shareService->save($child);
+
+        return true;
+    }
+
+    /**
+     * Applies the permissions of the group share to the share of a member
+     *
+     * @param Share $groupShare
+     * @param Share $child
+     *
+     * @return bool Whether anything changed
+     */
+    protected function copyPermissions(Share $groupShare, Share $child): bool {
+        $changed = false;
+
+        if($child->isEditable() !== $groupShare->isEditable()) {
+            $child->setEditable($groupShare->isEditable());
+            $changed = true;
+        }
+
+        if($child->isShareable() !== $groupShare->isShareable()) {
+            $child->setShareable($groupShare->isShareable());
+            $changed = true;
+        }
+
+        if($child->getExpires() !== $groupShare->getExpires()) {
+            $child->setExpires($groupShare->getExpires());
+            $changed = true;
+        }
+
+        return $changed;
+    }
+}

--- a/src/lib/Helper/Sharing/RecipientSearchHelper.php
+++ b/src/lib/Helper/Sharing/RecipientSearchHelper.php
@@ -29,6 +29,12 @@ class RecipientSearchHelper {
     const int USER_SEARCH_LIMIT   = 256;
 
     /**
+     * Pseudo group of the guests app. Being in it does not make users colleagues,
+     * so it must never be used to find recipients or as a recipient itself.
+     */
+    const string GUEST_GROUP = 'guest_app';
+
+    /**
      * RecipientSearchHelper constructor.
      *
      * @param IManager             $shareManager
@@ -89,7 +95,7 @@ class RecipientSearchHelper {
         if($this->userManager->userExists($recipient)) return $recipient;
 
         $recipients = $this->findRecipientSuggestions($recipient);
-        if(count($recipients) === 1) return $recipients[0]['uid'];
+        if(count($recipients) === 1) return $recipients[0]['id'];
 
         throw new ApiException('Invalid receiver uid', Http::STATUS_BAD_REQUEST);
     }
@@ -107,10 +113,27 @@ class RecipientSearchHelper {
         $user       = $this->userManager->get($uid);
         $userGroups = $this->groupManager->getUserGroupIds($this->environment->getUser());
         foreach($userGroups as $userGroup) {
-            if($this->groupManager->get($userGroup)->inGroup($user) && $userGroup !== 'guest_app') return true;
+            if($this->groupManager->get($userGroup)->inGroup($user) && $userGroup !== self::GUEST_GROUP) return true;
         }
 
         return false;
+    }
+
+    /**
+     * Whether the current user is allowed to share with the given group.
+     * This is the only place where group share permissions are checked,
+     * the cron job expands group shares with system privileges.
+     *
+     * @param string $groupId
+     *
+     * @return bool
+     */
+    public function canShareWithGroup(string $groupId): bool {
+        if(!$this->shareSettings->get('groups.enabled')) return false;
+        if($groupId === self::GUEST_GROUP) return false;
+        if($this->groupManager->get($groupId) === null) return false;
+
+        return $this->groupManager->isInGroup($this->environment->getUserId(), $groupId);
     }
 
     /**
@@ -144,7 +167,7 @@ class RecipientSearchHelper {
         $autocomplete = $this->shareSettings->get('autocomplete');
 
         foreach($userGroups as $userGroup) {
-            if($userGroup === 'guest_app') continue;
+            if($userGroup === self::GUEST_GROUP) continue;
             $users     = $this->groupManager->displayNamesInGroup($userGroup, $query, $limit);
             $groupName = $this->groupManager->getDisplayName($userGroup);
 
@@ -220,6 +243,7 @@ class RecipientSearchHelper {
 
         $recipients = [];
         foreach($matchingGroups as $group) {
+            if($group->getGID() === self::GUEST_GROUP) continue;
             if(!in_array($group->getGID(), $userGroups)) continue;
             if(!$autocomplete && $group->getGID() !== $query && $group->getDisplayName() !== $query) continue;
 

--- a/src/lib/Migration/Version20260804.php
+++ b/src/lib/Migration/Version20260804.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Passwords\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Class Version20260804
+ *
+ * @package OCA\Passwords\Migration
+ */
+class Version20260804 extends SimpleMigrationStep {
+    /**
+     * Human readable name of the migration step
+     *
+     * @return string
+     * @since 14.0.0
+     */
+    public function name(): string {
+        return 'Add support for group shares';
+    }
+
+    /**
+     * Human readable description of the migration step
+     *
+     * @return string
+     * @since 14.0.0
+     */
+    public function description(): string {
+        return 'Add the parent_share field to the shares table which links a share created for a group member to the group share';
+    }
+
+    /**
+     * @param IOutput $output
+     * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+     * @param array   $options
+     *
+     * @return null|ISchemaWrapper
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+        /** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+
+        $table = $schema->getTable('passwords_share');
+
+        if(!$table->hasColumn('parent_share')) {
+            $output->info('Creating column parent_share in table passwords_share');
+            $table->addColumn(
+                'parent_share',
+                'string',
+                [
+                    'notnull' => false,
+                    'default' => null,
+                    'length'  => 36,
+                ]
+            );
+        }
+
+        if(!$table->hasIndex('share_parent_share_index')) {
+            $output->info('Creating index share_parent_share_index in table passwords_share');
+            $table->addIndex(['parent_share'], 'share_parent_share_index');
+        }
+
+        return $schema;
+    }
+}

--- a/src/lib/Services/Object/ShareService.php
+++ b/src/lib/Services/Object/ShareService.php
@@ -99,7 +99,8 @@ class ShareService extends AbstractService {
     public function findBySourceUpdated(): array {
         return $this->mapper->findAllByFields(
             ['source_updated', true, IQueryBuilder::PARAM_BOOL],
-            ['target_updated', null, IQueryBuilder::PARAM_NULL, 'neq']
+            ['target_updated', null, IQueryBuilder::PARAM_NULL, 'neq'],
+            ['type', Share::TYPE_GROUP, IQueryBuilder::PARAM_STR, 'neq']
         );
     }
 
@@ -129,11 +130,48 @@ class ShareService extends AbstractService {
     }
 
     /**
+     * All shares which were created for a group instead of a single user
+     *
+     * @return Share[]
+     * @throws Exception
+     */
+    public function findAllGroupShares(): array {
+        return $this->mapper->findAllByField('type', Share::TYPE_GROUP);
+    }
+
+    /**
+     * All shares which were created from the given group share
+     *
+     * @param string $shareUuid
+     *
+     * @return Share[]
+     * @throws Exception
+     */
+    public function findByParentShare(string $shareUuid): array {
+        return $this->mapper->findAllByField('parent_share', $shareUuid);
+    }
+
+    /**
+     * All shares which were created for the member of a group share
+     *
+     * @return Share[]
+     * @throws Exception
+     */
+    public function findAllDerivedShares(): array {
+        return $this->mapper->findAllByField('parent_share', null, IQueryBuilder::PARAM_NULL, 'neq');
+    }
+
+    /**
+     * Group shares are never turned into a password, so they are excluded here
+     *
      * @return Share[]
      * @throws Exception
      */
     public function findNew(): array {
-        return $this->mapper->findAllByField('target_password', null, IQueryBuilder::PARAM_NULL);
+        return $this->mapper->findAllByFields(
+            ['target_password', null, IQueryBuilder::PARAM_NULL],
+            ['type', Share::TYPE_GROUP, IQueryBuilder::PARAM_STR, 'neq']
+        );
     }
 
     /**
@@ -158,10 +196,12 @@ class ShareService extends AbstractService {
     /**
      * @param string   $passwordId
      * @param string   $receiverId
-     * @param string   $type
-     * @param bool     $editable
-     * @param int|null $expires
-     * @param bool     $shareable
+     * @param string      $type
+     * @param bool        $editable
+     * @param int|null    $expires
+     * @param bool        $shareable
+     * @param string|null $parentShare
+     * @param string|null $userId      Owner of the share. Required when there is no user session, e.g. in the cron job
      *
      * @return Share|ModelInterface
      */
@@ -171,21 +211,25 @@ class ShareService extends AbstractService {
         string $type,
         bool $editable,
         ?int $expires = null,
-        bool $shareable = true
+        bool $shareable = true,
+        ?string $parentShare = null,
+        ?string $userId = null
     ): Share {
-        $model = $this->createModel($passwordId, $receiverId, $type, $editable, $expires, $shareable);
+        $model = $this->createModel($passwordId, $receiverId, $type, $editable, $expires, $shareable, $parentShare, $userId);
         $this->fireEvent('instantiated', $model);
 
         return $model;
     }
 
     /**
-     * @param string   $passwordId
-     * @param string   $receiverId
-     * @param string   $type
-     * @param bool     $editable
-     * @param int|null $expires
-     * @param bool     $shareable
+     * @param string      $passwordId
+     * @param string      $receiverId
+     * @param string      $type
+     * @param bool        $editable
+     * @param int|null    $expires
+     * @param bool        $shareable
+     * @param string|null $parentShare
+     * @param string|null $userId
      *
      * @return Share
      */
@@ -195,12 +239,14 @@ class ShareService extends AbstractService {
         string $type,
         bool $editable,
         ?int $expires,
-        bool $shareable
+        bool $shareable,
+        ?string $parentShare = null,
+        ?string $userId = null
     ): Share {
 
         $model = new Share();
         $model->setDeleted(false);
-        $model->setUserId($this->userId);
+        $model->setUserId($userId ?? $this->userId);
         $model->setUuid($this->uuidHelper->generateUuid());
         $model->setCreated(time());
         $model->setUpdated(time());
@@ -208,6 +254,7 @@ class ShareService extends AbstractService {
         $model->setSourcePassword($passwordId);
         $model->setSourceUpdated(true);
         $model->setReceiver($receiverId);
+        $model->setParentShare($parentShare);
         $model->setShareable($shareable);
         $model->setEditable($editable);
         $model->setExpires($expires);

--- a/src/vue/Components/Sidebar/PasswordSidebar/Sharing/Share.vue
+++ b/src/vue/Components/Sidebar/PasswordSidebar/Sharing/Share.vue
@@ -6,7 +6,8 @@
             <translate icon="calendar" :class="{active: share.expires}" :title="getExpirationDateTitle" @click="setExpires(share)"/>
             <translate icon="trash" title="Stop sharing" @click="deleteAction(share)"/>
         </div>
-        <img :src="share.receiver.icon" :alt="share.receiver.name" class="avatar" loading="lazy" width="32" height="32">
+        <account-group-icon :size="32" class="avatar group-avatar" v-if="isGroupShare"/>
+        <img :src="share.receiver.icon" :alt="share.receiver.name" class="avatar" loading="lazy" width="32" height="32" v-else>
         <div v-if="share.updatePending" class="loading"></div>
         {{ share.receiver.name }}
     </li>
@@ -18,10 +19,12 @@
     import SettingsService from "@js/Services/SettingsService";
     import MessageService from "@js/Services/MessageService";
     import LocalisationService from "@js/Services/LocalisationService";
+    import AccountGroupIcon from "@icon/AccountGroup";
 
     export default {
         components: {
-            Translate
+            Translate,
+            AccountGroupIcon
         },
 
         props: {
@@ -40,9 +43,15 @@
         },
 
         computed: {
+            isGroupShare() {
+                return this.share.receiver.type === 'group';
+            },
             getTitle() {
                 if(this.share.updatePending) {
                     return LocalisationService.translate('Some data is waiting to be synchronized');
+                }
+                if(this.isGroupShare) {
+                    return LocalisationService.translate('ShareTabGroupShareHint');
                 }
                 return undefined;
             },
@@ -143,6 +152,14 @@
         margin-right  : 5px;
         height        : 32px;
         width         : 32px;
+    }
+
+    .group-avatar {
+        border-radius    : 16px;
+        margin-right     : 5px;
+        height           : 32px;
+        width            : 32px;
+        background-color : var(--color-background-darker);
     }
 
     .options {

--- a/src/vue/Components/Sidebar/PasswordSidebar/Sharing/Sharing.vue
+++ b/src/vue/Components/Sidebar/PasswordSidebar/Sharing/Sharing.vue
@@ -9,47 +9,55 @@
             <translate say="{name} has shared this password with you." :variables="password.share.owner"/>
             <translate say="It will expire {date}." :variables="getExpirationDate" v-if="getDefaultExpires"/>
         </div>
-        <field v-model="search"
-               class="share-add-user"
-               placeholder="Search user"
-               @keypress="submitAction($event)" v-if="canBeShared"/>
-        <ul class="shares" v-if="shares.length !== 0">
+        <nc-select-users class="share-add-user"
+                         :options="matches"
+                         :placeholder="t('ShareTabSearchPlaceholder')"
+                         :input-label="t('ShareTabSelectRecipientLabel')"
+                         :multiple="false"
+                         :loading="searching"
+                         v-model="selected"
+                         @search="searchRecipients"
+                         v-if="canBeShared"/>
+        <ul class="shares" v-if="visibleShares.length !== 0">
             <share :share="share"
                    v-on:delete="deleteShare($event)"
                    v-on:update="refreshShares()"
                    :data-share-id="share.id"
                    :editable="isEditable"
-                   v-for="share in shares"
+                   v-for="share in visibleShares"
                    :key="share.id"/>
-        </ul>
-        <ul :class="getDropdownClasses" v-if="matches.length !== 0">
-            <li v-for="match in matches" @click="shareWithUser(match.id)">
-                <img :src="getAvatarUrl(match.id)" alt="" class="avatar">&nbsp;{{ match.name }}
-            </li>
         </ul>
     </div>
 </template>
 
 <script>
-    import Field from '@vc/Field';
     import API from '@js/Helper/api';
     import Translate from '@vc/Translate';
+    import NcSelectUsers from '@nc/NcSelectUsers.js';
     import Share from '@vc/Sidebar/PasswordSidebar/Sharing/Share';
-    import PasswordManager from '@js/Manager/PasswordManager';
     import SettingsService from '@js/Services/SettingsService';
     import ToastService from "@js/Services/ToastService";
-    import UtilityService from "@js/Services/UtilityService";
     import LocalisationService from "@js/Services/LocalisationService";
     import LoggingService from "@js/Services/LoggingService";
+    import CreateShareAction from "@js/Actions/Share/CreateShareAction";
+    import CreateShareError from "@js/Actions/Share/CreateShareError";
     import {getCurrentUser} from '@nextcloud/auth';
     import BatchActionManager from "@js/Manager/BatchActionManager";
     import {subscribe, subscribeOnce, unsubscribe} from "@js/Helper/event-bus";
 
+    /**
+     * The api reports errors with the crc32 hash of the message of the exception.
+     * "Invalid receiver uid" and "Invalid recipient uid" are thrown when the user
+     * can not be found, "Invalid recipient group" when the group can not be found.
+     */
+    const UNKNOWN_USER_ERRORS  = ['65782183', '6a935de5'];
+    const UNKNOWN_GROUP_ERRORS = ['5abffc24'];
+
     export default {
         components: {
-            Field,
             Share,
-            Translate
+            Translate,
+            NcSelectUsers
         },
 
         props: {
@@ -63,13 +71,13 @@
                 hasCse = this.password.cseType !== 'none' && !this.password.shared;
 
             return {
-                search      : '',
                 matches     : [],
-                nameMap     : [],
-                idMap       : [],
+                selected    : null,
+                searching   : false,
                 shares,
                 hasCse,
                 autocomplete: SettingsService.get('server.sharing.autocomplete'),
+                groupSharing: SettingsService.get('server.sharing.groups.enabled'),
                 interval    : null,
                 polling     : {interval: null, mode: null},
                 cronPromise : null,
@@ -153,74 +161,100 @@
 
                 return text;
             },
-            getDropdownClasses() {
-                let classes = ['user-search'];
+            /**
+             * The shares created by the server for the members of a group share
+             * are hidden, the group share itself represents them
+             */
+            visibleShares() {
+                let shares = [];
 
-                if(this.isSharedWithUser) classes.push('shared-with');
+                for(let id in this.shares) {
+                    if(!this.shares.hasOwnProperty(id)) continue;
+                    if(this.shares[id].parentShare) continue;
 
-                return classes;
+                    shares.push(this.shares[id]);
+                }
+
+                return shares;
             }
         },
 
         methods: {
-            async searchUsers() {
-                if(this.search === '' || !this.autocomplete || !this.canBeShared) {
+            async searchRecipients(query) {
+                if(!this.canBeShared) {
                     this.matches = [];
                     return;
                 }
 
-                const users   = this.getSharedWithUsers,
-                    matches = await API.findSharePartners(this.search, users.length + 10);
+                if(!this.autocomplete) {
+                    // Without autocomplete no suggestions are returned, so the typed id is offered as is
+                    this.matches = query === '' ? []:[{id: query, displayName: query, isNoUser: false, type: 'user'}];
+                    return;
+                }
 
-                this.matches = [];
-                for(let i in matches) {
-                    if(!matches.hasOwnProperty(i) || users.indexOf(i) !== -1) continue;
-                    let name = matches[i];
+                const receivers = this.getSharedWithUsers;
 
-                    this.matches.push({id: i, name});
-                    this.nameMap[name] = i;
-                    this.idMap[i] = name;
+                this.searching = true;
+                try {
+                    let matches      = await API.findShareRecipients(query, receivers.length + 25),
+                        groupSubname = LocalisationService.translate('BatchShareSubnameGroup'),
+                        options      = [];
+
+
+                    for(let match of matches) {
+                        if(receivers.indexOf(match.id) !== -1) continue;
+                        if(match.type === 'group' && !this.groupSharing) continue;
+
+                        options.push(
+                            {
+                                id         : match.id,
+                                displayName: match.name,
+                                isNoUser   : match.type === 'group',
+                                subname    : match.type === 'group' ? groupSubname:match.context,
+                                type       : match.type
+                            }
+                        );
+                    }
+
+                    this.matches = options;
+                } catch(e) {
+                    LoggingService.error(e);
+                } finally {
+                    this.searching = false;
                 }
             },
-            async disableCse() {
-                let password = UtilityService.cloneObject(this.password);
-                password.shared = true;
+            async addShare(recipient) {
+                if(!this.canBeShared || recipient === null) return;
 
-                await PasswordManager.updatePassword(password);
-                this.hasCse = false;
-            },
-            async addShare(receiver) {
-                if(!this.canBeShared) return;
-                if(this.hasCse) await this.disableCse();
-
-                let share = {
-                    password : this.password.id,
-                    expires  : this.getDefaultExpires,
-                    editable : SettingsService.get('user.sharing.editable'),
-                    shareable: SettingsService.get('user.sharing.resharing'),
-                    receiver
-                };
+                let action = new CreateShareAction(
+                    this.password,
+                    recipient,
+                    {
+                        expires  : this.getDefaultExpires,
+                        editable : SettingsService.get('user.sharing.editable'),
+                        shareable: SettingsService.get('user.sharing.resharing'),
+                        overwrite: false
+                    }
+                );
 
                 try {
-                    let d = await API.createShare(share);
-                    this.getSharedWithUsers.push(receiver);
-                    share.id = d.id;
-                    share.updatePending = true;
-                    share.owner = {
-                        id  : this.user.uid,
-                        name: this.user.displayName
-                    };
-                    share.receiver = {id: receiver, name: this.idMap[receiver]};
-                    this.shares[d.id] = await API._processShare(share);
-                    this.search = '';
+                    await action.run();
+                    this.matches = [];
                     this.refreshShares();
                 } catch(e) {
-                    if(e.id === '65782183') {
-                        ToastService.error(['The user {uid} does not exist', {uid: receiver}]);
+                    if(e instanceof CreateShareError) {
+                        ToastService.error(e.message);
+                    } else if(UNKNOWN_GROUP_ERRORS.indexOf(e.id) !== -1) {
+                        ToastService.error(['ShareTabGroupDoesNotExist', {group: recipient.displayName}]);
+                    } else if(UNKNOWN_USER_ERRORS.indexOf(e.id) !== -1) {
+                        ToastService.error(['The user {uid} does not exist', {uid: recipient.id}]);
                     } else {
                         let message = e.hasOwnProperty('message') ? e.message:e.statusText;
                         ToastService.error(['Unable to share password: {message}', {message}]);
                     }
+                } finally {
+                    // Disabling the encryption can not be undone, even if the share failed afterwards
+                    if(action.cseDisabled) this.hasCse = false;
                 }
             },
             reloadShares() {
@@ -228,28 +262,8 @@
                    .then((d) => {this.shares = d.shares;})
                    .catch(LoggingService.catch);
             },
-            submitAction($event) {
-                if($event.keyCode === 13) {
-                    let uid = this.search;
-                    if(this.nameMap.hasOwnProperty(uid)) {
-                        uid = this.nameMap[uid];
-                    }
-
-                    if(this.idMap.hasOwnProperty(uid) || !this.autocomplete) {
-                        this.addShare(uid);
-                    } else {
-                        ToastService.error(['The user {uid} does not exist', {uid}]);
-                    }
-                }
-            },
-            shareWithUser(uid) {
-                this.addShare(uid);
-            },
-            getAvatarUrl(uid) {
-                return API.getAvatarUrl(uid);
-            },
             deleteShare($event) {
-                delete this.shares[$event.id];
+                this.$delete(this.shares, $event.id);
                 this.refreshShares();
             },
             async refreshShares() {
@@ -314,8 +328,11 @@
 
                 this.$forceUpdate();
             },
-            search() {
-                this.searchUsers();
+            selected(recipient) {
+                if(recipient === null) return;
+
+                this.selected = null;
+                this.addShare(recipient);
             },
             shares(shares) {
                 for(let id in shares) {
@@ -359,33 +376,6 @@
 
     .shares {
         margin-top : 5px;
-    }
-
-    .user-search {
-        position         : absolute;
-        top              : 37px;
-        width            : 100%;
-        border-radius    : var(--border-radius);
-        z-index          : 2;
-        background-color : var(--color-main-background);
-        color            : var(--color-primary);
-        border           : 1px solid var(--color-primary);
-
-        &.shared-with {
-            top : 77px;
-        }
-
-        li {
-            line-height : 32px;
-            display     : flex;
-            padding     : 3px;
-            cursor      : pointer;
-
-            &:hover {
-                color            : var(--color-primary-text);
-                background-color : var(--color-primary);
-            }
-        }
     }
 }
 </style>

--- a/src/vue/Dialog/BatchActions/BatchShareDialog.vue
+++ b/src/vue/Dialog/BatchActions/BatchShareDialog.vue
@@ -20,7 +20,6 @@
             <div class="pw-batch-share">
                 <nc-note-card type="warning" :text="t('BatchActionShareDialogPasswordsOnlyWarning')" v-if="passwordsOnlyWarning"/>
                 <nc-note-card type="warning" :text="t('BatchActionShareDialogCseDisableWarning')" v-if="cseDisableWarning"/>
-                <nc-note-card type="warning" :text="t('BatchActionShareDialogGroupShareWarning')" v-if="groupShareWarning"/>
 
                 <div class="select-users">
                     <nc-select-users :input-label="t('BatchActionShareSelectUsersLabel')"
@@ -153,6 +152,7 @@
             return {
                 selectedUsers    : null,
                 availableUsers   : [],
+                groupSharing     : SettingsService.get('server.sharing.groups.enabled'),
                 permissionLevel,
                 permissions      : {edit, share},
                 overwriteExisting: false,
@@ -173,9 +173,6 @@
             },
             canConfigure() {
                 return this.hasUsersSelected && this.permissionLevel !== 'delete';
-            },
-            groupShareWarning() {
-                return this.selectedUsers && this.selectedUsers.some(item => item.isNoUser);
             }
         },
         methods : {
@@ -188,6 +185,7 @@
                     if(this.selectedUsers !== null && this.selectedUsers.indexOf(match) !== -1) {
                         continue;
                     }
+                    if(match.type === 'group' && !this.groupSharing) continue;
 
                     users.push(
                         {

--- a/tests/phpunit/Classes/Entity.php
+++ b/tests/phpunit/Classes/Entity.php
@@ -1,13 +1,44 @@
 <?php
 namespace OCP\AppFramework\Db;
 
+/**
+ * Minimal stand-in for the Nextcloud entity base class.
+ * Implements enough of the magic accessor behaviour that the entities
+ * in src/lib/Db can be used in tests without a Nextcloud installation.
+ */
 class Entity {
 
-    public function getFieldTypes() {
+    private array $_updatedFields = [];
 
+    private array $_fieldTypes = [];
+
+    public function __call($methodName, $args) {
+        if(str_starts_with($methodName, 'set')) {
+            $this->setter(lcfirst(substr($methodName, 3)), $args);
+
+            return null;
+        }
+
+        if(str_starts_with($methodName, 'get')) {
+            return $this->getter(lcfirst(substr($methodName, 3)));
+        }
+
+        if(str_starts_with($methodName, 'is')) {
+            return $this->getter(lcfirst(substr($methodName, 2)));
+        }
+
+        throw new \BadFunctionCallException($methodName.' does not exist');
     }
 
-    public function addType() {
+    protected function markFieldUpdated(string $attribute): void {
+        $this->_updatedFields[ $attribute ] = true;
+    }
 
+    protected function addType($fieldName, $type): void {
+        $this->_fieldTypes[ $fieldName ] = $type;
+    }
+
+    public function getFieldTypes(): array {
+        return $this->_fieldTypes;
     }
 }

--- a/tests/phpunit/Classes/shells.php
+++ b/tests/phpunit/Classes/shells.php
@@ -87,6 +87,21 @@ namespace OCP\AppFramework\Bootstrap {
     interface IBootstrap {}
 }
 
+namespace OCP\AppFramework\Db {
+    class DoesNotExistException extends \Exception {}
+
+    class MultipleObjectsReturnedException extends \Exception {}
+}
+
+namespace OCP\Share {
+    interface IManager {
+        public function shareApiEnabled(): bool;
+        public function sharingDisabledForUser(?string $userId): bool;
+        public function allowGroupSharing(): bool;
+        public function allowEnumeration(): bool;
+    }
+}
+
 namespace OCP\L10N {
     use OCP\IUser;
     interface IFactory {
@@ -105,15 +120,31 @@ namespace OCP\L10N {
 
 namespace OCP {
     class IGroup {
+        public function getGID(): string {return '';}
+        public function getDisplayName(): string {return '';}
         public function getUsers() { return  []; }
+        public function inGroup(IUser $user): bool {return false;}
     }
 
     class IGroupManager {
-        public function get() {return new IGroup();}
+        public function get(string $gid) {return new IGroup();}
+        public function search(string $search, ?int $limit = null, ?int $offset = null): array {return [];}
+        // Untyped like the real interface, the user id can be null
+        public function isInGroup($userId, $group) {return false;}
+        public function getUserGroupIds(?IUser $user = null): array {return [];}
+        public function displayNamesInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): array {return [];}
+        public function getDisplayName(string $gid): ?string {return null;}
     }
 
     interface IUser {
         public function getUID();
+    }
+
+    class IUserManager {
+        public function get(string $uid) {return null;}
+        public function userExists(string $uid): bool {return false;}
+        public function searchDisplayName(string $pattern, ?int $limit = null, ?int $offset = null): array {return [];}
+        public function getByEmail(string $email): array {return [];}
     }
 
     class IURLGenerator {

--- a/tests/phpunit/Helper/Settings/ShareSettingsHelperTest.php
+++ b/tests/phpunit/Helper/Settings/ShareSettingsHelperTest.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * @copyright 2026 Passwords App
+ *
+ * @author Marius David Wieschollek
+ * @license AGPL-3.0
+ *
+ * This file is part of the Passwords App
+ * created by Marius David Wieschollek.
+ */
+
+namespace OCA\Passwords\Helper\Settings;
+
+use OCA\Passwords\Services\ConfigurationService;
+use OCP\Share\IManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ShareSettingsHelperTest
+ *
+ * @covers \OCA\Passwords\Helper\Settings\ShareSettingsHelper
+ */
+class ShareSettingsHelperTest extends TestCase {
+
+    /**
+     * @var MockObject|ConfigurationService
+     */
+    protected $config;
+
+    /**
+     * @var MockObject|IManager
+     */
+    protected $shareManager;
+
+    /**
+     * @var ShareSettingsHelper
+     */
+    protected $shareSettingsHelper;
+
+    protected function setUp(): void {
+        $this->config              = $this->createMock(ConfigurationService::class);
+        $this->shareManager        = $this->createMock(IManager::class);
+        $this->shareSettingsHelper = new ShareSettingsHelper('admin', $this->shareManager, $this->config);
+    }
+
+    /**
+     * A group share can only be created if group sharing is allowed by the server
+     */
+    public function testGetTypesIncludesGroupIfGroupSharingIsEnabled(): void {
+        $this->shareManager->method('allowGroupSharing')->willReturn(true);
+
+        $this->assertEquals(['user', 'group'], $this->shareSettingsHelper->get('types'));
+    }
+
+    public function testGetTypesOmitsGroupIfGroupSharingIsDisabled(): void {
+        $this->shareManager->method('allowGroupSharing')->willReturn(false);
+
+        $this->assertEquals(['user'], $this->shareSettingsHelper->get('types'));
+    }
+
+    public function testGetGroupsEnabledUsesTheShareManager(): void {
+        $this->shareManager->expects($this->once())->method('allowGroupSharing')->willReturn(true);
+
+        $this->assertTrue($this->shareSettingsHelper->get('groups.enabled'));
+    }
+
+    public function testListContainsTheGroupSettings(): void {
+        $this->shareManager->method('allowGroupSharing')->willReturn(true);
+        $this->shareManager->method('shareApiEnabled')->willReturn(true);
+        $this->shareManager->method('sharingDisabledForUser')->willReturn(false);
+        $this->shareManager->method('allowEnumeration')->willReturn(true);
+        $this->config->method('getAppValue')->willReturn('yes');
+
+        $settings = $this->shareSettingsHelper->list();
+
+        $this->assertTrue($settings['server.sharing.enabled']);
+        $this->assertTrue($settings['server.sharing.groups.enabled']);
+        $this->assertTrue($settings['server.sharing.resharing']);
+        $this->assertTrue($settings['server.sharing.autocomplete']);
+        $this->assertEquals(['user', 'group'], $settings['server.sharing.types']);
+    }
+
+    public function testSharingIsDisabledIfTheUserMayNotShare(): void {
+        $this->shareManager->method('shareApiEnabled')->willReturn(true);
+        $this->shareManager->method('sharingDisabledForUser')->with('admin')->willReturn(true);
+
+        $this->assertFalse($this->shareSettingsHelper->get('enabled'));
+    }
+
+    public function testSharingIsDisabledIfTheShareApiIsDisabled(): void {
+        $this->shareManager->method('shareApiEnabled')->willReturn(false);
+        $this->shareManager->method('sharingDisabledForUser')->willReturn(false);
+
+        $this->assertFalse($this->shareSettingsHelper->get('enabled'));
+    }
+
+    /**
+     * Without a user there is no user the sharing could be disabled for
+     */
+    public function testSharingWithoutAUserOnlyChecksTheShareApi(): void {
+        $helper = new ShareSettingsHelper(null, $this->shareManager, $this->config);
+        $this->shareManager->method('shareApiEnabled')->willReturn(true);
+        $this->shareManager->expects($this->never())->method('sharingDisabledForUser');
+
+        $this->assertTrue($helper->get('enabled'));
+    }
+
+    public function testResharingFollowsTheNextcloudSetting(): void {
+        $this->config->method('getAppValue')->with('shareapi_allow_resharing', 'yes', 'core')->willReturn('no');
+
+        $this->assertFalse($this->shareSettingsHelper->get('resharing'));
+    }
+}

--- a/tests/phpunit/Helper/Sharing/CreatePasswordShareHelperTest.php
+++ b/tests/phpunit/Helper/Sharing/CreatePasswordShareHelperTest.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ * @copyright 2026 Passwords App
+ *
+ * @author Marius David Wieschollek
+ * @license AGPL-3.0
+ *
+ * This file is part of the Passwords App
+ * created by Marius David Wieschollek.
+ */
+
+namespace OCA\Passwords\Helper\Sharing;
+
+use OCA\Passwords\Db\Share;
+use OCA\Passwords\Exception\ApiException;
+use OCA\Passwords\Helper\Settings\ShareSettingsHelper;
+use OCA\Passwords\Services\Object\PasswordRevisionService;
+use OCA\Passwords\Services\Object\PasswordService;
+use OCA\Passwords\Services\Object\ShareService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Class CreatePasswordShareHelperTest
+ *
+ * @covers \OCA\Passwords\Helper\Sharing\CreatePasswordShareHelper
+ */
+class CreatePasswordShareHelperTest extends TestCase {
+
+    /**
+     * @var MockObject|ShareSettingsHelper
+     */
+    protected $shareSettings;
+
+    /**
+     * @var CreatePasswordShareHelper
+     */
+    protected $createPasswordShareHelper;
+
+    protected function setUp(): void {
+        $this->shareSettings = $this->createMock(ShareSettingsHelper::class);
+
+        $this->createPasswordShareHelper = new CreatePasswordShareHelper(
+            $this->createMock(ShareService::class),
+            $this->shareSettings,
+            $this->createMock(PasswordService::class),
+            $this->createMock(PasswordRevisionService::class)
+        );
+    }
+
+    public function testUserSharesAreAlwaysAllowed(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(false);
+
+        $this->checkType(Share::TYPE_USER);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testGroupSharesAreAllowedIfGroupSharingIsEnabled(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(true);
+
+        $this->checkType(Share::TYPE_GROUP);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testGroupSharesAreRejectedIfGroupSharingIsDisabled(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(false);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Invalid share type');
+        $this->checkType(Share::TYPE_GROUP);
+    }
+
+    public function testLinkSharesAreStillRejected(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(true);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Invalid share type');
+        $this->checkType(Share::TYPE_LINK);
+    }
+
+    public function testUnknownSharesAreRejected(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(true);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Invalid share type');
+        $this->checkType('circle');
+    }
+
+    /**
+     * checkType is protected because it is only used from within the share creation
+     *
+     * @param string $type
+     *
+     * @throws ApiException
+     */
+    protected function checkType(string $type): void {
+        $method = new ReflectionMethod($this->createPasswordShareHelper, 'checkType');
+        $method->setAccessible(true);
+        $method->invoke($this->createPasswordShareHelper, $type);
+    }
+}

--- a/tests/phpunit/Helper/Sharing/GroupShareSyncHelperTest.php
+++ b/tests/phpunit/Helper/Sharing/GroupShareSyncHelperTest.php
@@ -1,0 +1,630 @@
+<?php
+/*
+ * @copyright 2026 Passwords App
+ *
+ * @author Marius David Wieschollek
+ * @license AGPL-3.0
+ *
+ * This file is part of the Passwords App
+ * created by Marius David Wieschollek.
+ */
+
+namespace OCA\Passwords\Helper\Sharing;
+
+use OCA\Passwords\Db\Share;
+use OCA\Passwords\Services\LoggingService;
+use OCA\Passwords\Services\Object\ShareService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class GroupShareSyncHelperTest
+ *
+ * @covers \OCA\Passwords\Helper\Sharing\GroupShareSyncHelper
+ */
+class GroupShareSyncHelperTest extends TestCase {
+
+    /**
+     * @var MockObject|ShareService
+     */
+    protected $shareService;
+
+    /**
+     * @var MockObject|IGroupManager
+     */
+    protected $groupManager;
+
+    /**
+     * @var MockObject|LoggingService
+     */
+    protected $logger;
+
+    /**
+     * @var GroupShareSyncHelper
+     */
+    protected $groupShareSyncHelper;
+
+    protected function setUp(): void {
+        $this->shareService = $this->createMock(ShareService::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+        $this->logger       = $this->createMock(LoggingService::class);
+
+        $this->groupShareSyncHelper = new GroupShareSyncHelper(
+            $this->shareService,
+            $this->groupManager,
+            $this->logger
+        );
+    }
+
+    public function testCreatesSharesForAllGroupMembers(): void {
+        $groupShare = $this->makeGroupShare();
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['max', 'erika']);
+        $this->shareService->method('findByParentShare')->willReturn([]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare]);
+
+        $created = [];
+        $this->shareService
+            ->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnCallback(
+                function ($passwordId, $receiverId, $type, $editable, $expires, $shareable, $parentShare, $userId) use (&$created) {
+                    $created[] = [
+                        'password' => $passwordId, 'receiver' => $receiverId, 'type' => $type, 'editable' => $editable,
+                        'expires'  => $expires, 'shareable' => $shareable, 'parent' => $parentShare, 'owner' => $userId
+                    ];
+
+                    return $this->makeShare($receiverId, 'group-share-uuid');
+                }
+            );
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(2, $result['created']);
+        $this->assertEquals(['max', 'erika'], array_column($created, 'receiver'));
+
+        foreach($created as $share) {
+            $this->assertEquals('password-uuid', $share['password']);
+            $this->assertEquals(Share::TYPE_USER, $share['type']);
+            $this->assertEquals('group-share-uuid', $share['parent']);
+            $this->assertEquals('owner', $share['owner']);
+            $this->assertTrue($share['editable']);
+            $this->assertFalse($share['shareable']);
+            $this->assertEquals(1900000000, $share['expires']);
+        }
+    }
+
+    /**
+     * A user can not share with themselves, so the owner is skipped
+     */
+    public function testSkipsTheOwnerOfTheGroupShare(): void {
+        $groupShare = $this->makeGroupShare();
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['owner', 'max']);
+        $this->shareService->method('findByParentShare')->willReturn([]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare]);
+
+        $this->shareService
+            ->expects($this->once())
+            ->method('create')
+            ->with('password-uuid', 'max')
+            ->willReturn($this->makeShare('max', 'group-share-uuid'));
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['created']);
+    }
+
+    /**
+     * A member who already got the password directly must not get a second share
+     */
+    public function testSkipsMembersWhoAlreadyHaveThePassword(): void {
+        $groupShare  = $this->makeGroupShare();
+        $directShare = $this->makeShare('max', null);
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['max', 'erika']);
+        $this->shareService->method('findByParentShare')->willReturn([]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare, $directShare]);
+
+        $this->shareService
+            ->expects($this->once())
+            ->method('create')
+            ->with('password-uuid', 'erika')
+            ->willReturn($this->makeShare('erika', 'group-share-uuid'));
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['created']);
+    }
+
+    public function testDeletesSharesOfFormerGroupMembers(): void {
+        $groupShare = $this->makeGroupShare();
+        $maxShare   = $this->makeShare('max', 'group-share-uuid');
+        $erikaShare = $this->makeShare('erika', 'group-share-uuid');
+
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['erika']);
+        $this->shareService->method('findByParentShare')->willReturn([$maxShare, $erikaShare]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare, $erikaShare]);
+
+        $this->shareService->expects($this->once())->method('delete')->with($maxShare);
+        $this->shareService->expects($this->never())->method('create');
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['deleted']);
+        $this->assertEquals(0, $result['created']);
+    }
+
+    public function testPropagatesPermissionChangesToTheMemberShares(): void {
+        $groupShare = $this->makeGroupShare();
+        $maxShare   = $this->makeShare('max', 'group-share-uuid');
+        $maxShare->setEditable(false);
+        $maxShare->setExpires(1800000000);
+        $maxShare->setSourceUpdated(false);
+
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['max']);
+        $this->shareService->method('findByParentShare')->willReturn([$maxShare]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare, $maxShare]);
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['updated']);
+        $this->assertTrue($maxShare->isEditable());
+        $this->assertEquals(1900000000, $maxShare->getExpires());
+        $this->assertTrue($maxShare->isSourceUpdated(), 'The password of the member has to be updated by the cron job');
+    }
+
+    /**
+     * Nothing may change when the members and the permissions did not change
+     */
+    public function testDoesNothingIfTheGroupIsAlreadyInSync(): void {
+        $groupShare = $this->makeGroupShare();
+        $groupShare->setSourceUpdated(false);
+        $maxShare = $this->makeShare('max', 'group-share-uuid');
+
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['max']);
+        $this->shareService->method('findByParentShare')->willReturn([$maxShare]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare, $maxShare]);
+
+        $this->shareService->expects($this->never())->method('create');
+        $this->shareService->expects($this->never())->method('delete');
+        $this->shareService->expects($this->never())->method('save');
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(['created' => 0, 'deleted' => 0, 'updated' => 0], $result);
+    }
+
+    /**
+     * The group share stays, but nothing can be done with a group which no longer exists
+     */
+    public function testSkipsGroupSharesOfDeletedGroups(): void {
+        $groupShare = $this->makeGroupShare();
+        $maxShare   = $this->makeShare('max', 'group-share-uuid');
+        $this->mockGroupShares([$groupShare]);
+        $this->groupManager->method('get')->with('developers')->willReturn(null);
+        $this->shareService->method('findByParentShare')->willReturn([$maxShare]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare, $maxShare]);
+
+        $this->shareService->expects($this->never())->method('create');
+        // An unresolvable group must not revoke the access of the members, that would destroy their passwords
+        $this->shareService->expects($this->never())->method('delete');
+        $this->logger->expects($this->once())->method('warning');
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(['created' => 0, 'deleted' => 0, 'updated' => 0], $result);
+    }
+
+    /**
+     * One broken group share may not stop the others from being synchronized
+     */
+    public function testContinuesAfterAFailedGroupShare(): void {
+        $broken  = $this->makeGroupShare('broken-uuid', 'broken-group');
+        $working = $this->makeGroupShare();
+
+        $this->mockGroupShares([$broken, $working]);
+        $this->groupManager
+            ->method('get')
+            ->willReturnCallback(
+                function ($gid) {
+                    if($gid === 'broken-group') throw new \RuntimeException('group backend is down');
+
+                    return $this->makeGroup(['max']);
+                }
+            );
+        $this->shareService->method('findByParentShare')->willReturn([]);
+        $this->shareService->method('findBySourcePassword')->willReturn([]);
+
+        $this->shareService->expects($this->once())->method('create')->willReturn($this->makeShare('max', 'group-share-uuid'));
+        $this->logger->expects($this->once())->method('logException');
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['created']);
+    }
+
+    /**
+     * A user who moves from one group to another keeps the password if both groups
+     * have a share of it. The share is handed over to the other group share instead
+     * of being deleted, otherwise the password of the user would be deleted as well.
+     */
+    public function testMovesTheShareOfAMemberToAnotherGroupShareOfTheSamePassword(): void {
+        $alphaShare = $this->makeGroupShare('group-share-alpha', 'alpha');
+        $betaShare  = $this->makeGroupShare('group-share-beta', 'beta');
+        $maxShare   = $this->makeShare('max', 'group-share-beta');
+
+        // the group the member moves to grants different permissions
+        $alphaShare->setEditable(false);
+        $alphaShare->setShareable(true);
+        $alphaShare->setExpires(1800000000);
+
+        $this->mockGroupShares([$alphaShare, $betaShare]);
+        // max just joined alpha and left beta
+        $this->mockGroupMemberMap(['alpha' => ['max'], 'beta' => []]);
+        $this->shareService
+            ->method('findByParentShare')
+            ->willReturnCallback(fn($uuid) => $uuid === 'group-share-beta' ? [$maxShare]:[]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$alphaShare, $betaShare, $maxShare]);
+
+        $this->shareService->expects($this->never())->method('delete');
+        $this->shareService->expects($this->never())->method('create');
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(0, $result['deleted'], 'The member is still covered by the other group share');
+        $this->assertEquals(0, $result['created'], 'The share of the member is reused, not recreated');
+        $this->assertEquals('group-share-alpha', $maxShare->getParentShare());
+
+        // the member now has the permissions of the group they are in now
+        $this->assertFalse($maxShare->isEditable());
+        $this->assertTrue($maxShare->isShareable());
+        $this->assertEquals(1800000000, $maxShare->getExpires());
+        $this->assertTrue($maxShare->isSourceUpdated(), 'The password of the member has to be updated by the cron job');
+    }
+
+    /**
+     * Only a group share of the same password may take over the share of a member
+     */
+    public function testDoesNotMoveTheShareToAGroupShareOfAnotherPassword(): void {
+        $alphaShare = $this->makeGroupShare('group-share-alpha', 'alpha');
+        $alphaShare->setSourcePassword('another-password');
+        $betaShare = $this->makeGroupShare('group-share-beta', 'beta');
+        $maxShare  = $this->makeShare('max', 'group-share-beta');
+
+        $this->mockGroupShares([$alphaShare, $betaShare]);
+        $this->mockGroupMemberMap(['alpha' => ['max'], 'beta' => []]);
+        $this->shareService
+            ->method('findByParentShare')
+            ->willReturnCallback(fn($uuid) => $uuid === 'group-share-beta' ? [$maxShare]:[]);
+        $this->shareService->method('findBySourcePassword')->willReturn([]);
+        $this->shareService->method('create')->willReturn($this->makeShare('max', 'group-share-alpha'));
+
+        $this->shareService->expects($this->once())->method('delete')->with($maxShare);
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['deleted']);
+        $this->assertEquals('group-share-beta', $maxShare->getParentShare(), 'The share was not moved');
+    }
+
+    /**
+     * A group share of another user may not take over the share, the password of that
+     * user is a different password even if both were shared with the same group
+     */
+    public function testDoesNotMoveTheShareToAGroupShareOfAnotherOwner(): void {
+        $alphaShare = $this->makeGroupShare('group-share-alpha', 'alpha');
+        $alphaShare->setUserId('someone-else');
+        $betaShare = $this->makeGroupShare('group-share-beta', 'beta');
+        $maxShare  = $this->makeShare('max', 'group-share-beta');
+
+        $this->mockGroupShares([$alphaShare, $betaShare]);
+        $this->mockGroupMemberMap(['alpha' => ['max'], 'beta' => []]);
+        $this->shareService
+            ->method('findByParentShare')
+            ->willReturnCallback(fn($uuid) => $uuid === 'group-share-beta' ? [$maxShare]:[]);
+        $this->shareService->method('findBySourcePassword')->willReturn([]);
+        $this->shareService->method('create')->willReturn($this->makeShare('max', 'group-share-alpha'));
+
+        $this->shareService->expects($this->once())->method('delete')->with($maxShare);
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['deleted']);
+        $this->assertEquals('group-share-beta', $maxShare->getParentShare(), 'The share was not moved');
+    }
+
+    /**
+     * Deleting a group share revokes the password from its members,
+     * unless another group share of the same password still contains them
+     */
+    public function testRemoveGroupShareKeepsMembersCoveredByAnotherGroupShare(): void {
+        $alphaShare = $this->makeGroupShare('group-share-alpha', 'alpha');
+        $betaShare  = $this->makeGroupShare('group-share-beta', 'beta');
+        $maxShare   = $this->makeShare('max', 'group-share-beta');
+        $erikaShare = $this->makeShare('erika', 'group-share-beta');
+
+        $this->shareService->method('findAllGroupShares')->willReturn([$alphaShare, $betaShare]);
+        $this->mockGroupMemberMap(['alpha' => ['max'], 'beta' => ['max', 'erika']]);
+        $this->shareService
+            ->method('findByParentShare')
+            ->willReturnCallback(fn($uuid) => $uuid === 'group-share-beta' ? [$maxShare, $erikaShare]:[]);
+
+        // erika is only in the deleted group share, max is also in alpha
+        $this->shareService->expects($this->once())->method('delete')->with($erikaShare);
+
+        $this->groupShareSyncHelper->removeGroupShare($betaShare);
+
+        $this->assertEquals('group-share-alpha', $maxShare->getParentShare());
+    }
+
+    /**
+     * If nobody covers the member anymore the share has to go
+     */
+    public function testDeletesTheShareIfNoOtherGroupShareCoversTheMember(): void {
+        $alphaShare = $this->makeGroupShare('group-share-alpha', 'alpha');
+        $betaShare  = $this->makeGroupShare('group-share-beta', 'beta');
+        $maxShare   = $this->makeShare('max', 'group-share-beta');
+
+        $this->mockGroupShares([$alphaShare, $betaShare]);
+        $this->mockGroupMemberMap(['alpha' => [], 'beta' => []]);
+        $this->shareService
+            ->method('findByParentShare')
+            ->willReturnCallback(fn($uuid) => $uuid === 'group-share-beta' ? [$maxShare]:[]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$alphaShare, $betaShare]);
+
+        $this->shareService->expects($this->once())->method('delete')->with($maxShare);
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['deleted']);
+    }
+
+    /**
+     * If the password reached the owner of the group share through other users,
+     * sharing it back to them would be undone by the loop detection of the cron
+     * job and recreated on every run
+     */
+    public function testSkipsEveryoneThePasswordWasSharedThroughBefore(): void {
+        $groupShare = $this->makeGroupShare();
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['max', 'erika', 'jane']);
+        $this->shareService->method('findByParentShare')->willReturn([]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare]);
+
+        // password-uuid belongs to 'owner' and was shared to them by 'erika', who got it from 'jane'
+        $erikaShare = $this->makeShare('owner', null);
+        $erikaShare->setUserId('erika');
+        $erikaShare->setSourcePassword('erika-password');
+        $janeShare = $this->makeShare('erika', null);
+        $janeShare->setUserId('jane');
+        $janeShare->setSourcePassword('jane-password');
+
+        $this->shareService
+            ->method('findByTargetPassword')
+            ->willReturnCallback(
+                function ($passwordUuid) use ($erikaShare, $janeShare) {
+                    if($passwordUuid === 'password-uuid') return $erikaShare;
+                    if($passwordUuid === 'erika-password') return $janeShare;
+
+                    throw new DoesNotExistException('no parent share');
+                }
+            );
+
+        $created = [];
+        $this->shareService
+            ->method('create')
+            ->willReturnCallback(
+                function ($passwordId, $receiverId) use (&$created) {
+                    $created[] = $receiverId;
+
+                    return $this->makeShare($receiverId, 'group-share-uuid');
+                }
+            );
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(['max'], $created, 'erika and jane are further up in the share lineage');
+        $this->assertEquals(1, $result['created']);
+    }
+
+    /**
+     * The end of the share lineage is the normal case for a password the owner created
+     * themselves. It may not be reported as an error, that would flood the log.
+     */
+    public function testDoesNotLogTheEndOfTheShareLineage(): void {
+        $groupShare = $this->makeGroupShare();
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['max']);
+        $this->shareService->method('findByParentShare')->willReturn([]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare]);
+        $this->shareService->method('create')->willReturn($this->makeShare('max', 'group-share-uuid'));
+        $this->shareService
+             ->method('findByTargetPassword')
+             ->willThrowException(new DoesNotExistException('the password was not shared with the owner'));
+
+        $this->logger->expects($this->never())->method('logException');
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['created']);
+    }
+
+    /**
+     * A real problem while reading the lineage still has to be reported
+     */
+    public function testLogsAFailureWhileReadingTheShareLineage(): void {
+        $groupShare = $this->makeGroupShare();
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['max']);
+        $this->shareService->method('findByParentShare')->willReturn([]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare]);
+        $this->shareService->method('create')->willReturn($this->makeShare('max', 'group-share-uuid'));
+        $this->shareService
+             ->method('findByTargetPassword')
+             ->willThrowException(new \RuntimeException('the database is gone'));
+
+        $this->logger->expects($this->once())->method('logException');
+
+        $this->groupShareSyncHelper->synchronize();
+    }
+
+    /**
+     * The members of a group which can not be resolved are unknown, so their shares
+     * are kept instead of deleting the passwords of people who may still be members
+     */
+    public function testRemoveGroupShareKeepsMembersIfAnotherGroupCanNotBeResolved(): void {
+        $alphaShare = $this->makeGroupShare('group-share-alpha', 'alpha');
+        $betaShare  = $this->makeGroupShare('group-share-beta', 'beta');
+        $maxShare   = $this->makeShare('max', 'group-share-beta');
+
+        $this->shareService->method('findAllGroupShares')->willReturn([$alphaShare, $betaShare]);
+        // alpha can not be resolved right now
+        $this->mockGroupMemberMap(['beta' => ['max']]);
+        $this->shareService
+            ->method('findByParentShare')
+            ->willReturnCallback(fn($uuid) => $uuid === 'group-share-beta' ? [$maxShare]:[]);
+
+        $this->shareService->expects($this->never())->method('delete');
+
+        $this->groupShareSyncHelper->removeGroupShare($betaShare);
+
+        $this->assertEquals('group-share-alpha', $maxShare->getParentShare(), 'The decision is left to a later run');
+    }
+
+    /**
+     * A share whose group share is gone would never be looked at again,
+     * so the member would keep the password forever
+     */
+    public function testDeletesSharesWhoseGroupShareNoLongerExists(): void {
+        $groupShare  = $this->makeGroupShare();
+        $orphanShare = $this->makeShare('max', 'deleted-group-share');
+
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', []);
+        $this->shareService->method('findByParentShare')->willReturn([]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare]);
+        $this->shareService->method('findAllDerivedShares')->willReturn([$orphanShare]);
+
+        $this->shareService->expects($this->once())->method('delete')->with($orphanShare);
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals(1, $result['deleted']);
+    }
+
+    /**
+     * Unless another group share still covers the member
+     */
+    public function testKeepsOrphanedSharesWhichAreStillCoveredByAGroupShare(): void {
+        $groupShare  = $this->makeGroupShare();
+        $orphanShare = $this->makeShare('max', 'deleted-group-share');
+
+        $this->mockGroupShares([$groupShare]);
+        $this->mockGroupMembers('developers', ['max']);
+        $this->shareService->method('findByParentShare')->willReturn([]);
+        $this->shareService->method('findBySourcePassword')->willReturn([$groupShare, $orphanShare]);
+        $this->shareService->method('findAllDerivedShares')->willReturn([$orphanShare]);
+
+        $this->shareService->expects($this->never())->method('delete');
+
+        $result = $this->groupShareSyncHelper->synchronize();
+
+        $this->assertEquals('group-share-uuid', $orphanShare->getParentShare());
+        $this->assertEquals(1, $result['updated']);
+    }
+
+    /**
+     * @param Share[] $shares
+     */
+    protected function mockGroupShares(array $shares): void {
+        $this->shareService->method('findAllGroupShares')->willReturn($shares);
+    }
+
+    /**
+     * @param string   $groupId
+     * @param string[] $members
+     */
+    protected function mockGroupMembers(string $groupId, array $members): void {
+        $this->groupManager->method('get')->with($groupId)->willReturn($this->makeGroup($members));
+    }
+
+    /**
+     * @param array $groups Group id => member uids
+     */
+    protected function mockGroupMemberMap(array $groups): void {
+        $this->groupManager
+             ->method('get')
+             ->willReturnCallback(
+                 fn($gid) => array_key_exists($gid, $groups) ? $this->makeGroup($groups[ $gid ]):null
+             );
+    }
+
+    /**
+     * @param string[] $members
+     *
+     * @return MockObject|IGroup
+     */
+    protected function makeGroup(array $members) {
+        $users = [];
+        foreach($members as $member) {
+            $user = $this->createMock(IUser::class);
+            $user->method('getUID')->willReturn($member);
+            $users[] = $user;
+        }
+
+        $group = $this->createMock(IGroup::class);
+        $group->method('getUsers')->willReturn($users);
+
+        return $group;
+    }
+
+    protected function makeGroupShare(string $uuid = 'group-share-uuid', string $groupId = 'developers'): Share {
+        $share = new Share();
+        $share->setUuid($uuid);
+        $share->setUserId('owner');
+        $share->setDeleted(false);
+        $share->setType(Share::TYPE_GROUP);
+        $share->setReceiver($groupId);
+        $share->setParentShare(null);
+        $share->setSourcePassword('password-uuid');
+        $share->setSourceUpdated(true);
+        $share->setTargetUpdated(false);
+        $share->setEditable(true);
+        $share->setShareable(false);
+        $share->setExpires(1900000000);
+        $share->setClient('CLIENT::TEST');
+        $share->setCreated(1700000000);
+        $share->setUpdated(1700000000);
+
+        return $share;
+    }
+
+    protected function makeShare(string $receiver, ?string $parentShare): Share {
+        $share = new Share();
+        $share->setUuid('share-'.$receiver);
+        $share->setUserId('owner');
+        $share->setDeleted(false);
+        $share->setType(Share::TYPE_USER);
+        $share->setReceiver($receiver);
+        $share->setParentShare($parentShare);
+        $share->setSourcePassword('password-uuid');
+        $share->setSourceUpdated(false);
+        $share->setTargetUpdated(false);
+        $share->setEditable(true);
+        $share->setShareable(false);
+        $share->setExpires(1900000000);
+        $share->setClient('CLIENT::TEST');
+        $share->setCreated(1700000000);
+        $share->setUpdated(1700000000);
+
+        return $share;
+    }
+}

--- a/tests/phpunit/Helper/Sharing/RecipientSearchHelperTest.php
+++ b/tests/phpunit/Helper/Sharing/RecipientSearchHelperTest.php
@@ -1,0 +1,137 @@
+<?php
+/*
+ * @copyright 2026 Passwords App
+ *
+ * @author Marius David Wieschollek
+ * @license AGPL-3.0
+ *
+ * This file is part of the Passwords App
+ * created by Marius David Wieschollek.
+ */
+
+namespace OCA\Passwords\Helper\Sharing;
+
+use OCA\Passwords\Helper\Settings\ShareSettingsHelper;
+use OCA\Passwords\Services\ConfigurationService;
+use OCA\Passwords\Services\EnvironmentService;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\Share\IManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class RecipientSearchHelperTest
+ *
+ * Covers the permission check for group shares. It is the only place where the
+ * permissions of a group share are checked, the cron job expands them with
+ * system privileges afterwards.
+ *
+ * @covers \OCA\Passwords\Helper\Sharing\RecipientSearchHelper
+ */
+class RecipientSearchHelperTest extends TestCase {
+
+    /**
+     * @var MockObject|IGroupManager
+     */
+    protected $groupManager;
+
+    /**
+     * @var MockObject|ShareSettingsHelper
+     */
+    protected $shareSettings;
+
+    /**
+     * @var MockObject|EnvironmentService
+     */
+    protected $environment;
+
+    /**
+     * @var RecipientSearchHelper
+     */
+    protected $recipientSearchHelper;
+
+    protected function setUp(): void {
+        $this->groupManager  = $this->createMock(IGroupManager::class);
+        $this->shareSettings = $this->createMock(ShareSettingsHelper::class);
+        $this->environment   = $this->createMock(EnvironmentService::class);
+
+        $this->environment->method('getUserId')->willReturn('max');
+
+        $this->recipientSearchHelper = new RecipientSearchHelper(
+            $this->createMock(IManager::class),
+            $this->createMock(IUserManager::class),
+            $this->groupManager,
+            $this->createMock(ConfigurationService::class),
+            $this->environment,
+            $this->shareSettings
+        );
+    }
+
+    public function testCanShareWithAGroupTheUserIsMemberOf(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(true);
+        $this->groupManager->method('get')->with('developers')->willReturn($this->createMock(IGroup::class));
+        $this->groupManager->method('isInGroup')->with('max', 'developers')->willReturn(true);
+
+        $this->assertTrue($this->recipientSearchHelper->canShareWithGroup('developers'));
+    }
+
+    /**
+     * The membership of the group which was actually requested has to be checked,
+     * being in any other group is not enough
+     */
+    public function testChecksTheMembershipOfTheRequestedGroup(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(true);
+        $this->groupManager
+             ->method('get')
+             ->willReturnCallback(fn($gid) => $gid === 'accounting' ? $this->createMock(IGroup::class):null);
+        $this->groupManager
+             ->method('isInGroup')
+             ->willReturnCallback(fn($uid, $gid) => $uid === 'max' && $gid === 'accounting');
+
+        $this->assertTrue($this->recipientSearchHelper->canShareWithGroup('accounting'));
+        $this->assertFalse($this->recipientSearchHelper->canShareWithGroup('developers'));
+    }
+
+    /**
+     * Sharing with a group the user does not belong to would leak the password
+     * to a group of people the user can not even see
+     */
+    public function testCanNotShareWithAGroupTheUserIsNotMemberOf(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(true);
+        $this->groupManager->method('get')->with('developers')->willReturn($this->createMock(IGroup::class));
+        $this->groupManager->method('isInGroup')->with('max', 'developers')->willReturn(false);
+
+        $this->assertFalse($this->recipientSearchHelper->canShareWithGroup('developers'));
+    }
+
+    public function testCanNotShareWithAGroupIfGroupSharingIsDisabled(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(false);
+        $this->groupManager->method('get')->willReturn($this->createMock(IGroup::class));
+        $this->groupManager->method('isInGroup')->willReturn(true);
+
+        $this->assertFalse($this->recipientSearchHelper->canShareWithGroup('developers'));
+    }
+
+    public function testCanNotShareWithAGroupWhichDoesNotExist(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(true);
+        $this->groupManager->method('get')->with('developers')->willReturn(null);
+        $this->groupManager->method('isInGroup')->willReturn(true);
+
+        $this->assertFalse($this->recipientSearchHelper->canShareWithGroup('developers'));
+    }
+
+    /**
+     * Every guest is a member of the pseudo group of the guests app. Sharing with it
+     * would share the password with every guest of the server, which is exactly what
+     * canShareWithUser() prevents for single users.
+     */
+    public function testCanNotShareWithTheGuestGroup(): void {
+        $this->shareSettings->method('get')->with('groups.enabled')->willReturn(true);
+        $this->groupManager->method('get')->willReturn($this->createMock(IGroup::class));
+        $this->groupManager->method('isInGroup')->willReturn(true);
+
+        $this->assertFalse($this->recipientSearchHelper->canShareWithGroup(RecipientSearchHelper::GUEST_GROUP));
+    }
+}


### PR DESCRIPTION
### ⚠️ Disclosure

This contribution was made using AI

---

Closes #582

## What this does

Passwords can now be shared with a Nextcloud group. Both halves of the issue are covered:

1. Selecting a group in the share tab shares the password with its members.
2. A user who **joins the group later** receives the password automatically on the next
   run of the sharing cron, and loses it again when they leave the group.

## How it works

A group share is stored as a regular share of type `group` whose receiver is a group id.
The sharing cron expands it into one share per group member, linked back to the group
share by the new nullable `parent_share` column, and keeps that list in sync with the
current members of the group.

```
row A: type=group  receiver=Marketing  parent_share=NULL     <- what the user creates
row B: type=user   receiver=max        parent_share=A.uuid   <- created by the cron
row C: type=user   receiver=erika      parent_share=A.uuid   <- created by the cron
```

This keeps the existing "one share, one password copy" model intact, so `ShareMapper`,
the password materialisation and the whole notification machinery are unchanged. The
shares created for the members are hidden in the interface, the group share represents them.

If a member is in two groups which both have a share of the same password, the share is
handed over to the other group share instead of being deleted and recreated, so the member
keeps the password (and anything they shared onward from it).

## Screenshots

**Groups appear in the share tab, marked as a group**

<img src="https://raw.githubusercontent.com/LeoColman/passwords/pr-582-assets/.github/pr-assets/582/01-group-suggestion.png" width="420">

**One entry for the group, not one per member**

<img src="https://raw.githubusercontent.com/LeoColman/passwords/pr-582-assets/.github/pr-assets/582/02-group-shared.png" width="420">

**The member receives the password**

<img src="https://raw.githubusercontent.com/LeoColman/passwords/pr-582-assets/.github/pr-assets/582/03-member-received.png" width="900">

**User shares and group shares side by side, unchanged for users**

<img src="https://raw.githubusercontent.com/LeoColman/passwords/pr-582-assets/.github/pr-assets/582/04-user-and-group-share.png" width="420">

## Tests

New unit tests (`GroupShareSyncHelperTest`, `RecipientSearchHelperTest`,
`CreatePasswordShareHelperTest`, `ShareSettingsHelperTest`) and an end to end test
(`cypress/e2e/group-share.cy.js`) covering create, late join, leave, and revoke.

```
$ npx cypress run --spec cypress/e2e/group-share.cy.js --browser chrome

  Share a password with a group
    ✓ Offers the group as a recipient in the share tab
    ✓ Creates a single share for the group, not one per member
    ✓ Shares the password with the members of the group
    ✓ Shares the password with a user who joins the group later
    ✓ Revokes the password from a user who leaves the group
    ✓ Revokes the password from everyone when the group share is deleted

  6 passing
```

## Nothing that worked before was changed

**Unit tests** — same failures before and after, 38 tests added:

| | Tests | Errors | Failures |
|---|---|---|---|
| master | 151 | 21 | 2 |
| this branch | 189 | 21 | 2 |

The 21 errors and 2 failures are pre-existing on master (the `intl` extension is missing
in the test image, plus one `CheckAppSettingsTest` expectation). Comparing the list of
failing test names before and after gives an empty diff, so no test that passed before fails now.

**Sharing with a single user** — the same script was run against master and against this
branch on the same Nextcloud, and the output is byte for byte identical:

```
== 1. create a password and share it with a single user ==
share created: yes
recipient has the password: yes
== 2. the share is listed for the owner with the right fields ==
shares on the password: 1
  receiver=max editable=True shareable=True
== 3. update the share (revoke edit permission) ==
update accepted: yes
== 4. re-sharing by the recipient is blocked once shareable is off ==
reshare rejected: yes
== 5. revoke the share ==
recipient still has the password: no
```

## Notes for review

* `cypress/e2e/handbook.cy.js` does not run on Nextcloud 34 on master either — the
  language setting is a combobox now and `cy.select()` fails on it. Unrelated to this change.
* Sharing with a group requires the sharer to be a member of that group, which matches the
  existing behaviour of the recipient search. The `guest_app` pseudo group of the guests app
  is excluded, otherwise a guest could share with every guest on the server.
* Known limitations, happy to address any of them: a member who deletes their copy of the
  password gets it back on the next cron run, and turning off group sharing in Nextcloud
  stops new group shares but does not tear down existing ones.
